### PR TITLE
Don't set /SUBSYSTEM:WINDOWS in librarian options

### DIFF
--- a/columns_ui-sdk.vcxproj
+++ b/columns_ui-sdk.vcxproj
@@ -156,9 +156,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib />
-    <Lib>
-      <SubSystem>Windows</SubSystem>
-    </Lib>
+    <Lib />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -183,9 +181,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib />
-    <Lib>
-      <SubSystem>Windows</SubSystem>
-    </Lib>
+    <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\columns_ui-sdk\base.h" />


### PR DESCRIPTION
Based on the description of it (see https://docs.microsoft.com/en-gb/cpp/build/reference/managing-a-library?view=vs-2019 and https://docs.microsoft.com/en-gb/cpp/build/reference/subsystem-specify-subsystem?view=vs-2019), it seems a bit weird to set it on a library.

Additionally, removing it works around a problem when using Clang and llvm-lib.