### PR TITLE
Extend splitter_item_t helper methods

### DIFF
--- a/splitter.h
+++ b/splitter.h
@@ -48,11 +48,25 @@ public:
         return false;
     }
 
-    void get_panel_config_to_array(pfc::array_t<uint8_t>& p_data, bool reset = false) const
+    void get_panel_config_to_array(pfc::array_t<uint8_t>& p_data, bool reset = false, bool refresh = false) const
     {
-        stream_writer_memblock_ref writer(p_data, reset);
-        get_panel_config(&writer);
+        const auto window = get_window_ptr();
+
+        if (refresh && window.is_valid()) {
+            window->get_config_to_array(p_data, fb2k::noAbort, reset);
+        } else {            
+            stream_writer_memblock_ref writer(p_data, reset);
+            get_panel_config(&writer);
+        }
     }
+
+    pfc::array_t<uint8_t> get_panel_config_to_array(bool refresh = false) const
+    {
+        pfc::array_t<uint8_t> data;
+        get_panel_config_to_array(data, false, refresh);
+        return data;
+    }
+
     void set_panel_config_from_ptr(const void* p_data, t_size p_size)
     {
         stream_reader_memblock_ref reader(p_data, p_size);


### PR DESCRIPTION
This extends the `splitter_item_t::get_panel_config_to_array()` helper method to add a refresh parameter.

This makes the method fetch configuration data from the `window_ptr` when the splitter item has one, falling back to saved data otherwise.

It also adds an overload of the method that returns the configuration data directly rather than using an output parameter.