### PR TITLE
Remove legacy Win32 helpers code

### DIFF
--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -1,43 +1,7 @@
 #include "ui_extension.h"
 
-class param_utf16_from_utf8 : public pfc::stringcvt::string_wide_from_utf8 {
-    bool is_null;
-    WORD low_word;
-
-public:
-    param_utf16_from_utf8(const char* p)
-        : pfc::stringcvt::string_wide_from_utf8(p && HIWORD((DWORD)p) != 0 ? p : "")
-        , is_null(p == 0)
-        , low_word(HIWORD((DWORD)p) == 0 ? LOWORD((DWORD)p) : 0)
-    {
-    }
-    inline operator const WCHAR*() { return get_ptr(); }
-    const WCHAR* get_ptr()
-    {
-        return low_word ? (const WCHAR*)(DWORD)low_word
-                        : is_null ? 0 : pfc::stringcvt::string_wide_from_utf8::get_ptr();
-    }
-};
-
-class param_ansi_from_utf8 : public pfc::stringcvt::string_ansi_from_utf8 {
-    bool is_null;
-    WORD low_word;
-
-public:
-    param_ansi_from_utf8(const char* p)
-        : pfc::stringcvt::string_ansi_from_utf8(p && HIWORD((DWORD)p) != 0 ? p : "")
-        , is_null(p == 0)
-        , low_word(HIWORD((DWORD)p) == 0 ? LOWORD((DWORD)p) : 0)
-    {
-    }
-    inline operator const char*() { return get_ptr(); }
-    const char* get_ptr()
-    {
-        return low_word ? (const char*)(DWORD)low_word : is_null ? 0 : pfc::stringcvt::string_ansi_from_utf8::get_ptr();
-    }
-};
-
 namespace win32_helpers {
+
 void send_message_to_all_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARAM lp)
 {
     HWND wnd = GetWindow(wnd_parent, GW_CHILD);
@@ -47,6 +11,7 @@ void send_message_to_all_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARAM l
             SendMessage(wnd, msg, wp, lp);
         } while (wnd = GetWindow(wnd, GW_HWNDNEXT));
 }
+
 void send_message_to_direct_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARAM lp)
 {
     HWND wnd = GetWindow(wnd_parent, GW_CHILD);
@@ -55,11 +20,13 @@ void send_message_to_direct_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARA
             SendMessage(wnd, msg, wp, lp);
         } while (wnd = GetWindow(wnd, GW_HWNDNEXT));
 }
+
 int message_box(HWND wnd, const TCHAR* text, const TCHAR* caption, UINT type)
 {
     modal_dialog_scope scope(wnd);
     return MessageBox(wnd, text, caption, type);
 }
+
 }; // namespace win32_helpers
 
 int uHeader_SetItemWidth(HWND wnd, int n, UINT cx)
@@ -82,83 +49,66 @@ int uHeader_SetItemText(HWND wnd, int n, const char* text)
 
 int uHeader_InsertItem(HWND wnd, int n, uHDITEM* hdi, bool insert)
 {
-    if (IsUnicode()) {
-        param_utf16_from_utf8 text((hdi->mask & HDI_TEXT) ? hdi->pszText : 0);
-        HDITEMW hdw;
-        hdw.cchTextMax = text.length();
-        hdw.cxy = hdi->cxy;
-        hdw.fmt = hdi->fmt;
-        hdw.hbm = hdi->hbm;
-        hdw.iImage = hdi->iImage;
-        hdw.iOrder = hdi->iOrder;
-        hdw.lParam = hdi->lParam;
-        hdw.mask = hdi->mask;
-        hdw.pszText = const_cast<WCHAR*>(text.get_ptr());
+    pfc::stringcvt::string_wide_from_utf8 text_utf16;
 
-        return uSendMessage(wnd, insert ? HDM_INSERTITEMW : HDM_SETITEMW, n, (LPARAM)&hdw);
+    HDITEMW hdw{};
+    hdw.cxy = hdi->cxy;
+    hdw.fmt = hdi->fmt;
+    hdw.hbm = hdi->hbm;
+    hdw.iImage = hdi->iImage;
+    hdw.iOrder = hdi->iOrder;
+    hdw.lParam = hdi->lParam;
+    hdw.mask = hdi->mask;
 
-    } else {
-        param_ansi_from_utf8 text((hdi->mask & HDI_TEXT) ? hdi->pszText : 0);
-
-        HDITEMA hda;
-        hda.cchTextMax = hdi->cchTextMax;
-        hda.cxy = hdi->cxy;
-        hda.fmt = hdi->fmt;
-        hda.hbm = hdi->hbm;
-        hda.iImage = hdi->iImage;
-        hda.iOrder = hdi->iOrder;
-        hda.lParam = hdi->lParam;
-        hda.mask = hdi->mask;
-        hda.pszText = const_cast<char*>(text.get_ptr());
-
-        return uSendMessage(wnd, insert ? HDM_INSERTITEMA : HDM_SETITEMA, n, (LPARAM)&hda);
+    if (hdi->mask & HDI_TEXT) {
+        if (hdi->pszText == LPSTR_TEXTCALLBACKA) {
+            hdw.pszText = LPSTR_TEXTCALLBACKW;
+        } else {
+            text_utf16.convert(hdi->pszText);
+            hdw.pszText = const_cast<WCHAR*>(text_utf16.get_ptr());
+            hdw.cchTextMax = text_utf16.length();            
+        }
     }
+
+    return SendMessage(wnd, insert ? HDM_INSERTITEMW : HDM_SETITEMW, n, (LPARAM)&hdw);
 }
 
 BOOL uRebar_InsertItem(HWND wnd, int n, uREBARBANDINFO* rbbi, bool insert)
 {
-    BOOL rv = FALSE;
+    pfc::stringcvt::string_wide_from_utf8 text_utf16;
 
-    {
-        param_utf16_from_utf8 text((rbbi->fMask & RBBIM_TEXT) ? rbbi->lpText : 0);
+    REBARBANDINFOW rbw{};
+    rbw.cbSize = REBARBANDINFOW_V6_SIZE;
 
-        REBARBANDINFOW rbw;
-        rbw.cbSize = REBARBANDINFOW_V6_SIZE;
+    rbw.fMask = rbbi->fMask;
+    rbw.fStyle = rbbi->fStyle;
+    rbw.clrFore = rbbi->clrFore;
+    rbw.clrBack = rbbi->clrBack;
 
-        rbw.fMask = rbbi->fMask;
-        rbw.fStyle = rbbi->fStyle;
-        rbw.clrFore = rbbi->clrFore;
-        rbw.clrBack = rbbi->clrBack;
-        rbw.lpText = const_cast<WCHAR*>(text.get_ptr());
-        ;
-        rbw.cch = rbbi->cch;
-        rbw.iImage = rbbi->iImage;
-        rbw.hwndChild = rbbi->hwndChild;
-        rbw.cxMinChild = rbbi->cxMinChild;
-        rbw.cyMinChild = rbbi->cyMinChild;
-        rbw.cx = rbbi->cx;
-        rbw.hbmBack = rbbi->hbmBack;
-        rbw.wID = rbbi->wID;
+    if (rbbi->fMask & RBBIM_TEXT) {
+        text_utf16.convert(rbbi->lpText);
+        rbw.lpText = const_cast<WCHAR*>(text_utf16.get_ptr());
+    }
+    
+    rbw.iImage = rbbi->iImage;
+    rbw.hwndChild = rbbi->hwndChild;
+    rbw.cxMinChild = rbbi->cxMinChild;
+    rbw.cyMinChild = rbbi->cyMinChild;
+    rbw.cx = rbbi->cx;
+    rbw.hbmBack = rbbi->hbmBack;
+    rbw.wID = rbbi->wID;
 #if (_WIN32_IE >= 0x0400) // we should check size of structure instead so keeping compatibility is possible, but
                           // whatever
-        rbw.cyChild = rbbi->cyChild;
-        rbw.cyMaxChild = rbbi->cyMaxChild;
-        rbw.cyIntegral = rbbi->cyIntegral;
-        rbw.cxIdeal = rbbi->cxIdeal;
-        rbw.lParam = rbbi->lParam;
-        rbw.cxHeader = rbbi->cxHeader;
+    rbw.cyChild = rbbi->cyChild;
+    rbw.cyMaxChild = rbbi->cyMaxChild;
+    rbw.cyIntegral = rbbi->cyIntegral;
+    rbw.cxIdeal = rbbi->cxIdeal;
+    rbw.lParam = rbbi->lParam;
+    rbw.cxHeader = rbbi->cxHeader;
 #endif
 
-        rv = uSendMessage(wnd, insert ? RB_INSERTBANDW : RB_SETBANDINFOW, n, (LPARAM)&rbw);
-    }
-    return rv;
+    return SendMessage(wnd, insert ? RB_INSERTBANDW : RB_SETBANDINFOW, n, (LPARAM)&rbw);
 }
-
-#ifdef UNICODE
-#define param_os_from_utf8 param_utf16_from_utf8
-#else
-#define param_os_from_utf8 param_ansi_from_utf8
-#endif
 
 namespace win32_helpers {
 BOOL tooltip_add_tool(HWND wnd, TOOLINFO* ti, bool update)
@@ -171,37 +121,27 @@ BOOL tooltip_add_tool(HWND wnd, TOOLINFO* ti, bool update)
 
 BOOL uToolTip_AddTool(HWND wnd, uTOOLINFO* ti, bool update)
 {
-    BOOL rv = FALSE;
-    if (IsUnicode()) {
-        param_utf16_from_utf8 text(ti->lpszText);
-        TOOLINFOW tiw;
+    pfc::stringcvt::string_wide_from_utf8 text_utf16;
+    TOOLINFOW tiw{};
 
-        tiw.cbSize = sizeof(tiw);
-        tiw.uFlags = ti->uFlags;
-        tiw.hwnd = ti->hwnd;
-        tiw.uId = ti->uId;
-        tiw.rect = ti->rect;
-        tiw.hinst = ti->hinst;
-        tiw.lParam = ti->lParam;
-        tiw.lpszText = const_cast<WCHAR*>(text.get_ptr());
+    tiw.cbSize = sizeof(tiw);
+    tiw.uFlags = ti->uFlags;
+    tiw.hwnd = ti->hwnd;
+    tiw.uId = ti->uId;
+    tiw.rect = ti->rect;
+    tiw.hinst = ti->hinst;
+    tiw.lParam = ti->lParam;
 
-        rv = uSendMessage(wnd, update ? TTM_UPDATETIPTEXTW : TTM_ADDTOOLW, 0, (LPARAM)&tiw);
+    if (ti->lpszText == LPSTR_TEXTCALLBACKA) {
+        tiw.lpszText = LPSTR_TEXTCALLBACKW;
+    } else if (IS_INTRESOURCE(ti->lpszText)) {
+        tiw.lpszText = reinterpret_cast<LPWSTR>(ti->lpszText);
     } else {
-        param_ansi_from_utf8 text(ti->lpszText);
-        TOOLINFOA tia;
-
-        tia.cbSize = sizeof(tia);
-        tia.uFlags = ti->uFlags;
-        tia.hwnd = ti->hwnd;
-        tia.uId = ti->uId;
-        tia.rect = ti->rect;
-        tia.hinst = ti->hinst;
-        tia.lParam = ti->lParam;
-        tia.lpszText = const_cast<char*>(text.get_ptr());
-
-        rv = uSendMessage(wnd, update ? TTM_UPDATETIPTEXTA : TTM_ADDTOOLA, 0, (LPARAM)&tia);
+        text_utf16.convert(ti->lpszText);
+        tiw.lpszText = const_cast<WCHAR*>(text_utf16.get_ptr());
     }
-    return rv;
+
+    return SendMessage(wnd, update ? TTM_UPDATETIPTEXTW : TTM_ADDTOOLW, 0, (LPARAM)&tiw);
 }
 
 BOOL uTabCtrl_InsertItemText(HWND wnd, int idx, const char* text, bool insert)
@@ -217,7 +157,7 @@ BOOL uTabCtrl_InsertItemText(HWND wnd, int idx, const char* text, bool insert)
 
 BOOL uComboBox_GetText(HWND combo, UINT index, pfc::string_base& out)
 {
-    unsigned len = uSendMessage(combo, CB_GETLBTEXTLEN, index, 0);
+    unsigned len = SendMessage(combo, CB_GETLBTEXTLEN, index, 0);
     if (len == CB_ERR || len > 16 * 1024 * 1024)
         return FALSE;
     if (len == 0) {
@@ -225,27 +165,15 @@ BOOL uComboBox_GetText(HWND combo, UINT index, pfc::string_base& out)
         return TRUE;
     }
 
-    if (IsUnicode()) {
-        pfc::array_t<WCHAR> temp;
-        temp.set_size(len + 1);
-        if (temp.get_ptr() == 0)
-            return FALSE;
-        temp.fill(0);
-        len = uSendMessage(combo, CB_GETLBTEXT, index, (LPARAM)temp.get_ptr());
-        if (len == CB_ERR)
-            return false;
-        out.set_string(pfc::stringcvt::string_utf8_from_wide(temp.get_ptr()));
-    } else {
-        pfc::array_t<char> temp;
-        temp.set_size(len + 1);
-        if (temp.get_ptr() == 0)
-            return FALSE;
-        temp.fill(0);
-        len = uSendMessage(combo, CB_GETLBTEXT, index, (LPARAM)temp.get_ptr());
-        if (len == CB_ERR)
-            return false;
-        out.set_string(pfc::stringcvt::string_utf8_from_ansi(temp.get_ptr()));
-    }
+    pfc::array_t<WCHAR> temp;
+    temp.set_size(len + 1);
+    if (temp.get_ptr() == 0)
+        return FALSE;
+    temp.fill(0);
+    len = SendMessage(combo, CB_GETLBTEXT, index, (LPARAM)temp.get_ptr());
+    if (len == CB_ERR)
+        return false;
+    out.set_string(pfc::stringcvt::string_utf8_from_wide(temp.get_ptr()));
     return TRUE;
 }
 
@@ -255,76 +183,38 @@ BOOL uComboBox_SelectString(HWND combo, const char* src)
     idx = uSendMessageText(combo, CB_FINDSTRINGEXACT, -1, src);
     if (idx == CB_ERR)
         return false;
-    uSendMessage(combo, CB_SETCURSEL, idx, 0);
+    SendMessage(combo, CB_SETCURSEL, idx, 0);
     return TRUE;
 }
 
 BOOL uStatus_SetText(HWND wnd, int part, const char* text)
 {
-    BOOL rv = 0;
-
-    if (IsUnicode()) {
-        rv = uSendMessage(wnd, SB_SETTEXTW, part, (LPARAM)(param_utf16_from_utf8(text).get_ptr()));
-    } else {
-        rv = uSendMessage(wnd, SB_SETTEXTA, part, (LPARAM)(param_ansi_from_utf8(text).get_ptr()));
-    }
-
-    //    rv = uSendMessageText(wnd, IsUnicode() ? SB_SETTEXTW : SB_SETTEXTA, part, text);
-    return rv;
+    const pfc::stringcvt::string_wide_from_utf8 text_utf16(text);
+    return SendMessage(wnd, SB_SETTEXTW, part, (LPARAM)(text_utf16.get_ptr()));
 }
 
 HFONT uCreateIconFont()
 {
-    HFONT fnt_menu = 0;
+    LOGFONTW lf;
+    memset(&lf, 0, sizeof(LOGFONTW));
+    SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &lf, 0);
 
-    if (IsUnicode()) {
-        LOGFONTW lf;
-        memset(&lf, 0, sizeof(LOGFONTW));
-        SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &lf, 0);
-
-        fnt_menu = CreateFontIndirectW(&lf);
-    } else {
-        LOGFONTA lf;
-        memset(&lf, 0, sizeof(LOGFONTA));
-        SystemParametersInfoA(SPI_GETICONTITLELOGFONT, 0, &lf, 0);
-
-        fnt_menu = CreateFontIndirectA(&lf);
-    }
-
-    return fnt_menu;
+    return CreateFontIndirectW(&lf);
 }
 
 HFONT uCreateMenuFont(bool vertical)
 {
-    HFONT fnt_menu = 0;
+    NONCLIENTMETRICSW ncm;
+    memset(&ncm, 0, sizeof(NONCLIENTMETRICSW));
+    ncm.cbSize = sizeof(NONCLIENTMETRICSW);
+    SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncm, 0);
 
-    if (IsUnicode()) {
-        NONCLIENTMETRICSW ncm;
-        memset(&ncm, 0, sizeof(NONCLIENTMETRICSW));
-        ncm.cbSize = sizeof(NONCLIENTMETRICSW);
-        SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncm, 0);
-
-        if (vertical) {
-            ncm.lfMenuFont.lfEscapement = 900;
-            ncm.lfMenuFont.lfOrientation = 900;
-        }
-
-        fnt_menu = CreateFontIndirectW(&ncm.lfMenuFont);
-    } else {
-        NONCLIENTMETRICSA ncm;
-        memset(&ncm, 0, sizeof(NONCLIENTMETRICSA));
-        ncm.cbSize = sizeof(NONCLIENTMETRICSA);
-        SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncm, 0);
-
-        if (vertical) {
-            ncm.lfMenuFont.lfEscapement = 900;
-            ncm.lfMenuFont.lfOrientation = 900;
-        }
-
-        fnt_menu = CreateFontIndirectA(&ncm.lfMenuFont);
+    if (vertical) {
+        ncm.lfMenuFont.lfEscapement = 900;
+        ncm.lfMenuFont.lfOrientation = 900;
     }
 
-    return fnt_menu;
+    return CreateFontIndirectW(&ncm.lfMenuFont);
 }
 
 void uGetMenuFont(LOGFONT* p_lf)
@@ -345,44 +235,15 @@ void uGetIconFont(LOGFONT* p_lf)
 BOOL uFormatMessage(DWORD dw_error, pfc::string_base& out)
 {
     BOOL rv = FALSE;
-    if (IsUnicode()) {
-        pfc::array_t<WCHAR> buffer;
-        buffer.set_size(256);
-        // MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-        if (FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0, dw_error, 0, buffer.get_ptr(),
-                buffer.get_size(), 0)) {
-            out.set_string(pfc::stringcvt::string_utf8_from_wide(buffer.get_ptr()));
-            rv = TRUE;
-        }
-    } else {
-        pfc::array_t<char> buffer;
-        buffer.set_size(256);
-        if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0, dw_error, 0, buffer.get_ptr(),
-                buffer.get_size(), 0)) {
-            // is it actually ANSI ?
-            out.set_string(pfc::stringcvt::string_utf8_from_ansi(buffer.get_ptr()));
-            rv = TRUE;
-        }
+    pfc::array_t<WCHAR> buffer;
+    buffer.set_size(256);
+    // MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+    if (FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0, dw_error, 0, buffer.get_ptr(),
+            buffer.get_size(), 0)) {
+        out.set_string(pfc::stringcvt::string_utf8_from_wide(buffer.get_ptr()));
+        rv = TRUE;
     }
     return rv;
-}
-
-DWORD uSetClassLong(HWND wnd, int index, long new_long)
-{
-    if (IsUnicode()) {
-        return SetClassLongW(wnd, index, new_long);
-    } else {
-        return SetClassLongA(wnd, index, new_long);
-    }
-}
-
-DWORD uGetClassLong(HWND wnd, int index)
-{
-    if (IsUnicode()) {
-        return GetClassLongW(wnd, index);
-    } else {
-        return GetClassLongA(wnd, index);
-    }
 }
 
 #if (WINVER >= 0x0500)
@@ -413,111 +274,24 @@ HWND uRecursiveChildWindowFromPoint(HWND parent, POINT pt_parent)
 BOOL uGetMonitorInfo(HMONITOR monitor, LPMONITORINFO lpmi)
 {
     BOOL rv = FALSE;
-    if (IsUnicode()) {
-        if (lpmi->cbSize == sizeof(uMONITORINFOEX)) {
-            uLPMONITORINFOEX lpmiex = (uLPMONITORINFOEX)lpmi;
+    if (lpmi->cbSize == sizeof(uMONITORINFOEX)) {
+        uLPMONITORINFOEX lpmiex = (uLPMONITORINFOEX)lpmi;
 
-            MONITORINFOEXW mi;
-            memset(&mi, 0, sizeof(MONITORINFOEXW));
-            mi.cbSize = sizeof(MONITORINFOEXW);
+        MONITORINFOEXW mi;
+        memset(&mi, 0, sizeof(MONITORINFOEXW));
+        mi.cbSize = sizeof(MONITORINFOEXW);
 
-            rv = GetMonitorInfoW(monitor, &mi);
+        rv = GetMonitorInfoW(monitor, &mi);
 
-            lpmi->rcMonitor = mi.rcMonitor;
-            lpmi->rcWork = mi.rcWork;
-            lpmi->dwFlags = mi.dwFlags;
+        lpmi->rcMonitor = mi.rcMonitor;
+        lpmi->rcWork = mi.rcWork;
+        lpmi->dwFlags = mi.dwFlags;
 
-            pfc::stringcvt::string_utf8_from_wide temp(mi.szDevice, CCHDEVICENAME);
-            strcpy_utf8_truncate(temp, lpmiex->szDevice, CCHDEVICENAME);
-
-            // unsafe
-            /*    unsigned len = wcslen_max(mi.szDevice,CCHDEVICENAME);
-                convert_utf16_to_utf8(mi.szDevice,lpmiex->szDevice,len);*/
-        } else
-            rv = GetMonitorInfoW(monitor, lpmi);
-    } else {
-        if (lpmi->cbSize == sizeof(uMONITORINFOEX)) {
-            uLPMONITORINFOEX lpmiex = (uLPMONITORINFOEX)lpmi;
-
-            MONITORINFOEXA mi;
-            memset(&mi, 0, sizeof(MONITORINFOEXA));
-            mi.cbSize = sizeof(MONITORINFOEXA);
-
-            rv = GetMonitorInfoA(monitor, &mi);
-
-            lpmi->rcMonitor = mi.rcMonitor;
-            lpmi->rcWork = mi.rcWork;
-            lpmi->dwFlags = mi.dwFlags;
-
-            pfc::stringcvt::string_utf8_from_ansi temp(mi.szDevice, CCHDEVICENAME);
-            pfc::strcpy_utf8_truncate(temp, lpmiex->szDevice, CCHDEVICENAME);
-
-            /*unsigned len = strlen_max(mi.szDevice,CCHDEVICENAME);
-            convert_ansi_to_utf8(mi.szDevice,lpmiex->szDevice,len);*/
-        } else
-            rv = GetMonitorInfoA(monitor, lpmi);
-    }
+        pfc::stringcvt::string_utf8_from_wide temp(mi.szDevice, CCHDEVICENAME);
+        strcpy_utf8_truncate(temp, lpmiex->szDevice, CCHDEVICENAME);
+    } else
+        rv = GetMonitorInfoW(monitor, lpmi);
     return rv;
-}
-
-void strncpy_addnull(char* dest, const char* src, int max)
-{
-    int n;
-    for (n = 0; n < max - 1 && src[n]; n++)
-        dest[n] = src[n];
-    dest[n] = 0;
-}
-
-void wcsncpy_addnull(WCHAR* dest, const WCHAR* src, int max)
-{
-    int n;
-    for (n = 0; n < max - 1 && src[n]; n++)
-        dest[n] = src[n];
-    dest[n] = 0;
-}
-
-#ifdef UNICODE
-#define tcsncpy_addnull wcsncpy_addnull
-#else
-#define tcsncpy_addnull strncpy_addnull
-#endif
-
-typedef LOGFONTA uLOGFONT;
-
-void convert_logfont_utf8_to_os(const uLOGFONT& p_src, LOGFONT& p_dst)
-{
-    p_dst.lfHeight = p_src.lfHeight;
-    p_dst.lfWidth = p_src.lfWidth;
-    p_dst.lfEscapement = p_src.lfEscapement;
-    p_dst.lfOrientation = p_src.lfOrientation;
-    p_dst.lfWeight = p_src.lfWeight;
-    p_dst.lfItalic = p_src.lfItalic;
-    p_dst.lfUnderline = p_src.lfUnderline;
-    p_dst.lfStrikeOut = p_src.lfStrikeOut;
-    p_dst.lfCharSet = p_src.lfCharSet;
-    p_dst.lfOutPrecision = p_src.lfOutPrecision;
-    p_dst.lfClipPrecision = p_src.lfClipPrecision;
-    p_dst.lfQuality = p_src.lfQuality;
-    p_dst.lfPitchAndFamily = p_src.lfPitchAndFamily;
-    tcsncpy_addnull(p_dst.lfFaceName, pfc::stringcvt::string_os_from_utf8(p_src.lfFaceName), tabsize(p_dst.lfFaceName));
-}
-
-void convert_logfont_os_to_utf8(const LOGFONT& p_src, uLOGFONT& p_dst)
-{
-    p_dst.lfHeight = p_src.lfHeight;
-    p_dst.lfWidth = p_src.lfWidth;
-    p_dst.lfEscapement = p_src.lfEscapement;
-    p_dst.lfOrientation = p_src.lfOrientation;
-    p_dst.lfWeight = p_src.lfWeight;
-    p_dst.lfItalic = p_src.lfItalic;
-    p_dst.lfUnderline = p_src.lfUnderline;
-    p_dst.lfStrikeOut = p_src.lfStrikeOut;
-    p_dst.lfCharSet = p_src.lfCharSet;
-    p_dst.lfOutPrecision = p_src.lfOutPrecision;
-    p_dst.lfClipPrecision = p_src.lfClipPrecision;
-    p_dst.lfQuality = p_src.lfQuality;
-    p_dst.lfPitchAndFamily = p_src.lfPitchAndFamily;
-    strncpy_addnull(p_dst.lfFaceName, pfc::stringcvt::string_utf8_from_os(p_src.lfFaceName), tabsize(p_dst.lfFaceName));
 }
 
 #endif

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -94,17 +94,5 @@ int message_box(HWND wnd, const TCHAR* text, const TCHAR* caption, UINT type);
 BOOL tooltip_add_tool(HWND wnd, TOOLINFO* ti, bool update = false);
 }; // namespace win32_helpers
 
-// for compatibility only (namely fcs files)
-
-void convert_logfont_utf8_to_os(const uLOGFONT& p_src, LOGFONT& p_dst);
-void convert_logfont_os_to_utf8(const LOGFONT& p_src, uLOGFONT& p_dst);
-
-struct logfont_os_from_utf8 : public LOGFONT {
-    logfont_os_from_utf8(const uLOGFONT& p_logfont) { convert_logfont_utf8_to_os(p_logfont, *this); }
-};
-
-struct logfont_utf8_from_os : public uLOGFONT {
-    logfont_utf8_from_os(const LOGFONT& p_logfont) { convert_logfont_os_to_utf8(p_logfont, *this); }
-};
 
 #endif


### PR DESCRIPTION
This removes very old ANSI support from various Win32 helper functions, and removes a few redundant functions as well.

Note that most of these functions are no longer used in Columns UI and therefore may have bugs. Some will be marked as deprecated shortly.