### PR TITLE
Correct various integer types

### DIFF
--- a/buttons.h
+++ b/buttons.h
@@ -235,12 +235,12 @@ public:
         unsigned cy_hint, unsigned& handle_type) const = 0;
 
     /**
-     * \brief Not used.
+     * \brief Deprecated uie::button method, not used for uie::button_v2.
      */
-    virtual HBITMAP get_item_bitmap(unsigned command_state_index, COLORREF cr_btntext, t_mask& p_mask_type,
-        COLORREF& cr_mask, HBITMAP& bm_mask) const
+    HBITMAP get_item_bitmap(unsigned command_state_index, COLORREF cr_btntext, t_mask& p_mask_type, COLORREF& cr_mask,
+        HBITMAP& bm_mask) const override
     {
-        return NULL;
+        return nullptr;
     }
 
     FB2K_MAKE_SERVICE_INTERFACE(button_v2, button);
@@ -264,7 +264,7 @@ public:
 /** \brief Sub-class of uie::button, for buttons that implement their own command */
 class NOVTABLE custom_button : public button {
 public:
-    virtual t_button_guid get_guid_type() const { return BUTTON_GUID_BUTTON; }
+    t_button_guid get_guid_type() const override { return BUTTON_GUID_BUTTON; }
 
     /**
      * \brief Executes the custom button's command

--- a/columns_ui-sdk.vcxproj
+++ b/columns_ui-sdk.vcxproj
@@ -77,7 +77,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -100,7 +100,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -122,7 +122,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>ui_extension.h</PrecompiledHeaderFile>
@@ -145,7 +145,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>ui_extension.h</PrecompiledHeaderFile>

--- a/columns_ui.h
+++ b/columns_ui.h
@@ -131,8 +131,8 @@ class global_variable_list : public pfc::ptr_list_t<global_variable> {
 public:
     const char* find_by_name(const char* p_name, t_size length)
     {
-        unsigned n, count = get_count();
-        for (n = 0; n < count; n++) {
+        size_t count = get_count();
+        for (size_t n = 0; n < count; n++) {
             const char* ptr = get_item(n)->get_name();
             if (!stricmp_utf8_ex(p_name, length, ptr, pfc_infinite))
                 return get_item(n)->get_value();
@@ -152,15 +152,15 @@ class titleformat_hook_global_variables : public titleformat_hook {
     global_variable_list& p_vars;
 
 public:
-    virtual bool process_field(
-        titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag)
+    bool process_field(
+        titleformat_text_out* p_out, const char* p_name, size_t p_name_length, bool& p_found_flag) override
     {
         p_found_flag = false;
         return false;
     }
 
-    virtual bool process_function(titleformat_text_out* p_out, const char* p_name, unsigned p_name_length,
-        titleformat_hook_function_params* p_params, bool& p_found_flag)
+    bool process_function(titleformat_text_out* p_out, const char* p_name, size_t p_name_length,
+        titleformat_hook_function_params* p_params, bool& p_found_flag) override
     {
         p_found_flag = false;
         if (set && !stricmp_utf8_ex(p_name, p_name_length, "set_global", pfc_infinite)) {
@@ -255,10 +255,10 @@ public:
 /** Helper. Use group_impl_factory below. */
 class group_impl : public group {
 public:
-    virtual void get_name(pfc::string_base& p_out) const { p_out = m_name; }
-    virtual void get_description(pfc::string_base& p_out) const { p_out = m_desc; }
-    virtual const GUID& get_guid() const { return m_guid; }
-    virtual const GUID& get_parent_guid() const { return m_parent_guid; }
+    void get_name(pfc::string_base& p_out) const override { p_out = m_name; }
+    void get_description(pfc::string_base& p_out) const override { p_out = m_desc; }
+    const GUID& get_guid() const override { return m_guid; }
+    const GUID& get_parent_guid() const override { return m_parent_guid; }
 
     GUID m_guid, m_parent_guid;
     pfc::string8 m_name, m_desc;

--- a/columns_ui_appearance.h
+++ b/columns_ui_appearance.h
@@ -95,8 +95,8 @@ public:
  */
 class NOVTABLE common_callback {
 public:
-    virtual void on_colour_changed(t_size mask) const = 0;
-    virtual void on_bool_changed(t_size mask) const = 0;
+    virtual void on_colour_changed(uint32_t changed_items_mask) const = 0;
+    virtual void on_bool_changed(uint32_t changed_items_mask) const = 0;
 };
 
 /**
@@ -197,7 +197,7 @@ public:
     virtual const GUID& get_client_guid() const = 0;
     virtual void get_name(pfc::string_base& p_out) const = 0;
 
-    virtual t_size get_supported_colours() const
+    virtual uint32_t get_supported_colours() const
     {
         return cui::colours::colour_flag_all
             & ~(cui::colours::colour_flag_group_foreground | cui::colours::colour_flag_group_background);
@@ -208,23 +208,24 @@ public:
      *
      * If dark mode is supported by your panel, you should set the #bool_flag_dark_mode_enabled bit.
      */
-    virtual t_size get_supported_bools() const = 0; // bit-mask
+    virtual uint32_t get_supported_bools() const = 0; // bit-mask
     /** Indicates whether you are Theme API aware and can draw selected items using Theme API */
     virtual bool get_themes_supported() const = 0;
 
-    virtual void on_colour_changed(t_size mask) const = 0;
+    virtual void on_colour_changed(uint32_t changed_items_mask) const = 0;
 
     /**
      * Called whenever a supported boolean flag changes. Support for a flag is determined using the
      * get_supported_bools() method.
      *
-     * \param [in] mask     a combination of bool_flag_t indicating the flags that have changed.
-     *                      (Only indicates which flags have changed, not the new values.)
+     * \param [in] changed_items_mask  a combination of bool_flag_t indicating the flags that have
+     *                                 changed. (Only indicates which flags have changed, not the
+     *                                 new values.)
      *
      * \note Only #bool_flag_dark_mode_enabled is currently supported. Ensure you inspect mask to check
      * which flags have changed.
      */
-    virtual void on_bool_changed(t_size mask) const = 0;
+    virtual void on_bool_changed(uint32_t changed_items_mask) const = 0;
 
     template <class tClass>
     class factory : public service_factory_t<tClass> {
@@ -255,10 +256,10 @@ public:
         }
     }
 
-    void on_colour_changed(t_size mask) const override {}
-    void on_bool_changed(t_size mask) const override
+    void on_colour_changed(uint32_t changed_items_mask) const override {}
+    void on_bool_changed(uint32_t changed_items_mask) const override
     {
-        if (mask & bool_flag_dark_mode_enabled)
+        if (changed_items_mask & bool_flag_dark_mode_enabled)
             m_callback();
     }
 
@@ -291,7 +292,7 @@ enum font_type_flag_t {
  */
 class NOVTABLE common_callback {
 public:
-    virtual void on_font_changed(t_size mask) const = 0;
+    virtual void on_font_changed(uint32_t changed_items_mask) const = 0;
 };
 
 /** One implementation in Columns UI - do not reimplement! */

--- a/container_window_v2.h
+++ b/container_window_v2.h
@@ -55,7 +55,7 @@ public:
     class window_class_release_delayed : public main_thread_callback {
     public:
         window_class_release_delayed(GUID const& p_guid) : m_guid(p_guid){};
-        virtual void callback_run();
+        void callback_run() override;
         GUID m_guid;
     };
 
@@ -262,7 +262,7 @@ LRESULT container_window_v2_t<TBase>::__on_message(HWND wnd, UINT msg, WPARAM wp
     if (get_flags() & flag_transparent_background) {
         if (msg == WM_ERASEBKGND || (msg == WM_PRINTCLIENT && (lp & PRF_ERASEBKGND))) {
             HDC dc = (HDC)wp;
-            BOOL b_ret = TRUE;
+            LRESULT b_ret = TRUE;
 
             HWND wnd_parent = GetParent(wnd);
             POINT pt = {0, 0}, pt_old = {0, 0};

--- a/menu.h
+++ b/menu.h
@@ -81,33 +81,33 @@ public:
 /** \brief Base class for command menu items */
 class NOVTABLE menu_node_command_t : public menu_node_t {
 public:
-    type_t get_type() const { return type_command; };
-    t_size get_children_count() const { return 0; }
-    void get_child(t_size index, menu_node_ptr& p_out) const {}
+    type_t get_type() const override { return type_command; };
+    t_size get_children_count() const override { return 0; }
+    void get_child(t_size index, menu_node_ptr& p_out) const override {}
 };
 
 /** \brief Base class for popup menu items */
 class NOVTABLE menu_node_popup_t : public menu_node_t {
 public:
-    type_t get_type() const { return type_popup; };
-    void execute(){};
-    bool get_description(pfc::string_base& p_out) const { return false; }
+    type_t get_type() const override { return type_popup; };
+    void execute() override{};
+    bool get_description(pfc::string_base& p_out) const override { return false; }
 };
 
 /** \brief Implements menu_node_t as a separator item */
 class menu_node_separator_t : public menu_node_t {
 public:
-    type_t get_type() const { return type_separator; };
-    void execute(){};
-    bool get_description(pfc::string_base& p_out) const { return false; }
-    t_size get_children_count() const { return 0; }
-    bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+    type_t get_type() const override { return type_separator; };
+    void execute() override{};
+    bool get_description(pfc::string_base& p_out) const override { return false; }
+    t_size get_children_count() const override { return 0; }
+    bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override
     {
         p_out.reset();
         p_displayflags = 0;
         return true;
     }
-    void get_child(t_size index, menu_node_ptr& p_out) const {}
+    void get_child(t_size index, menu_node_ptr& p_out) const override {}
 };
 
 #if _MSC_VER >= 1800
@@ -169,14 +169,14 @@ class menu_hook_impl
     unsigned execute_by_id_recur(menu_node_ptr parent, unsigned base_id, unsigned max_id, unsigned id_exec);
 
 public:
-    virtual void add_node(const menu_node_ptr& p_node);
-    virtual t_size get_children_count() const;
-    virtual void get_child(t_size p_index, menu_node_ptr& p_out) const;
-    virtual type_t get_type() const;
+    void add_node(const menu_node_ptr& p_node) override;
+    t_size get_children_count() const override;
+    void get_child(t_size p_index, menu_node_ptr& p_out) const override;
+    type_t get_type() const override;
 
-    virtual bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const;
-    virtual bool get_description(pfc::string_base& p_out) const;
-    virtual void execute();
+    bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
+    bool get_description(pfc::string_base& p_out) const override;
+    void execute() override;
 
     void win32_build_menu(
         HMENU menu, unsigned base_id, unsigned max_id); // menu item identifiers are base_id<=N<base_id+max_id (if

--- a/splitter.h
+++ b/splitter.h
@@ -234,7 +234,7 @@ public:
 
 class stream_writer_fixedbuffer : public stream_writer {
 public:
-    void write(const void* p_buffer, t_size p_bytes, abort_callback& p_abort)
+    void write(const void* p_buffer, t_size p_bytes, abort_callback& p_abort) override
     {
         if (p_bytes > 0) {
             if (p_bytes > m_bytes - m_bytes_read)

--- a/ui_extension.h
+++ b/ui_extension.h
@@ -3,6 +3,7 @@
 
 #define UI_EXTENSION_VERSION "6.5"
 
+#include <algorithm>
 #include <utility>
 
 // Included first, because pfc.h includes winsock2.h
@@ -22,7 +23,7 @@
 
 // ripped from stream_reader::read_string_raw
 void stream_to_mem_block(stream_reader* p_source, pfc::array_t<t_uint8>& p_out, abort_callback& p_abort,
-    unsigned p_sizehint = 0, bool b_reset = false);
+    size_t p_sizehint = 0, bool b_reset = false);
 
 class stream_writer_memblock_ref : public stream_writer {
 public:
@@ -31,7 +32,7 @@ public:
         if (b_reset)
             m_data.set_size(0);
     };
-    void write(const void* p_buffer, t_size p_bytes, abort_callback& p_abort)
+    void write(const void* p_buffer, t_size p_bytes, abort_callback& p_abort) override
     {
         m_data.append_fromptr((t_uint8*)p_buffer, p_bytes);
     }
@@ -43,7 +44,7 @@ private:
 class stream_writer_memblock : public stream_writer {
 public:
     stream_writer_memblock(){};
-    void write(const void* p_buffer, t_size p_bytes, abort_callback& p_abort)
+    void write(const void* p_buffer, t_size p_bytes, abort_callback& p_abort) override
     {
         m_data.append_fromptr((t_uint8*)p_buffer, p_bytes);
     }

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -23,18 +23,18 @@ typedef TOOLINFOA uTOOLINFO;
 typedef REBARBANDINFOA uREBARBANDINFO;
 typedef LOGFONTA uLOGFONT;
 
-#define RECT_CX(rc) (rc.right - rc.left)
-#define RECT_CY(rc) (rc.bottom - rc.top)
+#define RECT_CX(rc) ((rc).right - (rc).left)
+#define RECT_CY(rc) ((rc).bottom - (rc).top)
 
 int uHeader_InsertItem(HWND wnd, int n, uHDITEM* hdi, bool insert = true); // set insert to false to set the item
                                                                            // instead
 int uHeader_SetItemText(HWND wnd, int n, const char* text);
 int uHeader_SetItemWidth(HWND wnd, int n, UINT cx);
-BOOL uToolTip_AddTool(HWND wnd, uTOOLINFO* ti, bool update = false);
-BOOL uRebar_InsertItem(
+bool uToolTip_AddTool(HWND wnd, uTOOLINFO* ti, bool update = false);
+bool uRebar_InsertItem(
     HWND wnd, int n, uREBARBANDINFO* rbbi, bool insert = true); // set insert to false to set the item instead
 
-BOOL uTabCtrl_InsertItemText(HWND wnd, int idx, const char* text,
+int uTabCtrl_InsertItemText(HWND wnd, int idx, const char* text,
     bool insert = true); // fixes '&' characters also, set insert to false to set the item instead
 
 inline void GetRelativeRect(HWND wnd, HWND wnd_parent, RECT* rc) // get rect of wnd in wnd_parent coordinates
@@ -43,9 +43,9 @@ inline void GetRelativeRect(HWND wnd, HWND wnd_parent, RECT* rc) // get rect of 
     MapWindowPoints(HWND_DESKTOP, wnd_parent, (LPPOINT)rc, 2);
 }
 
-BOOL uComboBox_GetText(HWND combo, UINT index, pfc::string_base& out);
-BOOL uComboBox_SelectString(HWND combo, const char* src);
-BOOL uStatus_SetText(HWND wnd, int part, const char* text);
+bool uComboBox_GetText(HWND combo, UINT index, pfc::string_base& out);
+bool uComboBox_SelectString(HWND combo, const char* src);
+bool uStatus_SetText(HWND wnd, int part, const char* text);
 
 HFONT uCreateIconFont();
 HFONT uCreateMenuFont(bool vertical = false);
@@ -75,9 +75,6 @@ inline BOOL uGetLastErrorMessage(pfc::string_base& out)
     return uFormatMessage(GetLastError(), out);
 }
 
-DWORD uGetClassLong(HWND wnd, int index);
-DWORD uSetClassLong(HWND wnd, int index, long new_long);
-
 HWND uFindParentPopup(HWND wnd_child);
 
 #if (WINVER >= 0x0500)
@@ -91,7 +88,7 @@ namespace win32_helpers {
 void send_message_to_all_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARAM lp);
 void send_message_to_direct_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARAM lp);
 int message_box(HWND wnd, const TCHAR* text, const TCHAR* caption, UINT type);
-BOOL tooltip_add_tool(HWND wnd, TOOLINFO* ti, bool update = false);
+bool tooltip_add_tool(HWND wnd, TOOLINFO* ti, bool update = false);
 }; // namespace win32_helpers
 
 

--- a/window.h
+++ b/window.h
@@ -380,14 +380,15 @@ class menu_node_configure : public uie::menu_node_command_t {
     pfc::string8 m_title;
 
 public:
-    virtual bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+    bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override
     {
         p_out = m_title;
         p_displayflags = 0;
         return true;
     }
-    virtual bool get_description(pfc::string_base& p_out) const { return false; }
-    virtual void execute() { p_this->show_config_popup(p_this->get_wnd()); }
+
+    bool get_description(pfc::string_base& p_out) const override { return false; }
+    void execute() override { p_this->show_config_popup(p_this->get_wnd()); }
     menu_node_configure(window* wnd, const char* p_title = "Options") : p_this(wnd), m_title(p_title){};
 };
 
@@ -430,7 +431,7 @@ public:
 
     ~window_factory() {}
 
-    virtual void instance_create(service_ptr_t<service_base>& p_out)
+    void instance_create(service_ptr_t<service_base>& p_out) override
     {
         service_impl_t<::window_implementation<T, false>>* item = new service_impl_t<::window_implementation<T, false>>;
         p_out = (service_base*)(window*)(::window_implementation<T, false>*)item;
@@ -455,7 +456,7 @@ public:
 
     ~window_factory_single() {}
 
-    virtual void instance_create(service_ptr_t<service_base>& p_out)
+    void instance_create(service_ptr_t<service_base>& p_out) override
     {
         p_out = (service_base*)(window*)(window_implementation<T, true>*)&g_instance;
     }
@@ -479,7 +480,7 @@ class window_factory_transparent_single
 public:
     window_factory_transparent_single() : service_factory_base_t<window>() {}
 
-    virtual void instance_create(service_ptr_t<service_base>& p_out)
+    void instance_create(service_ptr_t<service_base>& p_out) override
     {
         p_out = (service_base*)(window*)(window_implementation<T, true>*)this;
     }

--- a/window_helper.cpp
+++ b/window_helper.cpp
@@ -111,7 +111,7 @@ LRESULT WINAPI container_window::window_proc(HWND wnd, UINT msg, WPARAM wp, LPAR
     if (p_this && p_this->get_class_data().want_transparent_background) {
         if (msg == WM_ERASEBKGND || (msg == WM_PRINTCLIENT && (lp & PRF_ERASEBKGND))) {
             HDC dc = (HDC)wp;
-            BOOL b_ret = TRUE;
+            LRESULT b_ret = TRUE;
 
             HWND wnd_parent = GetParent(wnd);
             POINT pt = {0, 0}, pt_old = {0, 0};

--- a/window_helper.h
+++ b/window_helper.h
@@ -125,7 +125,7 @@ public:
         void deregister_window(container_window_release_t& ptr) { m_windows.remove_item(&ptr); }
 
     private:
-        void on_quit()
+        void on_quit() override
         {
             t_size i = m_windows.get_count();
             for (; i; i--) {


### PR DESCRIPTION
This corrects various integer types across the SDK.

It also defines NOMINMAX within the project (to disable the `min()` and `max()` macros), makes use of the `override` specifier and makes some other minor improvements.