### PR TITLE
Deprecate old Win32 helpers

### DIFF
--- a/win32_helpers.cpp
+++ b/win32_helpers.cpp
@@ -35,6 +35,7 @@ int uHeader_SetItemWidth(HWND wnd, int n, UINT cx)
     memset(&hdi, 0, sizeof(hdi));
     hdi.mask = HDI_WIDTH;
     hdi.cxy = cx;
+#pragma warning(suppress : 4996)
     return uHeader_InsertItem(wnd, n, &hdi, false);
 }
 int uHeader_SetItemText(HWND wnd, int n, const char* text)
@@ -44,6 +45,7 @@ int uHeader_SetItemText(HWND wnd, int n, const char* text)
     hdi.mask = HDI_TEXT;
     hdi.cchTextMax = NULL;
     hdi.pszText = const_cast<char*>(text);
+#pragma warning(suppress : 4996)
     return uHeader_InsertItem(wnd, n, &hdi, false);
 }
 

--- a/win32_helpers.h
+++ b/win32_helpers.h
@@ -1,50 +1,30 @@
-#ifndef _UI_EXTENSION_UTF8API_H_
-#define _UI_EXTENSION_UTF8API_H_
+#pragma once
 
-/**
- * \file win32_helpers.h
- * \brief UTF-8 Win32 API wrappers
- * \author musicmusic
- */
-
-#include <windows.h>
-#include <WindowsX.h>
-#include <commctrl.h>
-
-#ifndef uT
-#define uT(x) (pfc::stringcvt::string_os_from_utf8(x).get_ptr())
-#define uTS(x, s) (pfc::stringcvt::string_os_from_utf8(x, s).get_ptr())
-#endif
-#define Tu(x) (pfc::stringcvt::string_utf8_from_os(x).get_ptr())
-#define TSu(x, s) (pfc::stringcvt::string_utf8_from_os(x, s).get_ptr())
+#include <Windows.h>
+#include <windowsx.h>
+#include <CommCtrl.h>
 
 typedef HDITEMA uHDITEM;
 typedef TOOLINFOA uTOOLINFO;
 typedef REBARBANDINFOA uREBARBANDINFO;
-typedef LOGFONTA uLOGFONT;
 
 #define RECT_CX(rc) ((rc).right - (rc).left)
 #define RECT_CY(rc) ((rc).bottom - (rc).top)
 
-int uHeader_InsertItem(HWND wnd, int n, uHDITEM* hdi, bool insert = true); // set insert to false to set the item
-                                                                           // instead
-int uHeader_SetItemText(HWND wnd, int n, const char* text);
-int uHeader_SetItemWidth(HWND wnd, int n, UINT cx);
-bool uToolTip_AddTool(HWND wnd, uTOOLINFO* ti, bool update = false);
-bool uRebar_InsertItem(
-    HWND wnd, int n, uREBARBANDINFO* rbbi, bool insert = true); // set insert to false to set the item instead
+// set insert to false to set the item instead
+bool uRebar_InsertItem(HWND wnd, int n, uREBARBANDINFO* rbbi, bool insert = true);
 
-int uTabCtrl_InsertItemText(HWND wnd, int idx, const char* text,
-    bool insert = true); // fixes '&' characters also, set insert to false to set the item instead
+// fixes '&' characters also, set insert to false to set the item instead
+int uTabCtrl_InsertItemText(HWND wnd, int idx, const char* text, bool insert = true);
 
-inline void GetRelativeRect(HWND wnd, HWND wnd_parent, RECT* rc) // get rect of wnd in wnd_parent coordinates
+// get rect of wnd in wnd_parent coordinates
+inline void GetRelativeRect(HWND wnd, HWND wnd_parent, RECT* rc)
 {
     GetWindowRect(wnd, rc);
-    MapWindowPoints(HWND_DESKTOP, wnd_parent, (LPPOINT)rc, 2);
+    MapWindowPoints(HWND_DESKTOP, wnd_parent, reinterpret_cast<LPPOINT>(rc), 2);
 }
 
 bool uComboBox_GetText(HWND combo, UINT index, pfc::string_base& out);
-bool uComboBox_SelectString(HWND combo, const char* src);
 bool uStatus_SetText(HWND wnd, int part, const char* text);
 
 HFONT uCreateIconFont();
@@ -52,14 +32,6 @@ HFONT uCreateMenuFont(bool vertical = false);
 
 void uGetMenuFont(LOGFONT* p_lf);
 void uGetIconFont(LOGFONT* p_lf);
-
-struct logfont_os_menu : public LOGFONT {
-    logfont_os_menu() { uGetMenuFont(this); }
-};
-
-struct logfont_os_icon : public LOGFONT {
-    logfont_os_icon() { uGetIconFont(this); }
-};
 
 inline void GetMessagePos(LPPOINT pt)
 {
@@ -81,15 +53,23 @@ HWND uFindParentPopup(HWND wnd_child);
 typedef MONITORINFOEXA uMONITORINFOEX, *uLPMONITORINFOEX;
 
 BOOL uGetMonitorInfo(HMONITOR monitor, LPMONITORINFO lpmi);
-HWND uRecursiveChildWindowFromPoint(HWND parent, POINT pt_parent); // pt_parent is in parent window coordinates!
+// pt_parent is in parent window coordinates!
+HWND uRecursiveChildWindowFromPoint(HWND parent, POINT pt_parent);
 #endif
+
+[[deprecated("No longer maintained.")]] int uHeader_InsertItem(HWND wnd, int n, uHDITEM* hdi, bool insert = true);
+[[deprecated("No longer maintained.")]] int uHeader_SetItemText(HWND wnd, int n, const char* text);
+[[deprecated("No longer maintained.")]] int uHeader_SetItemWidth(HWND wnd, int n, UINT cx);
+[[deprecated("No longer maintained.")]] bool uToolTip_AddTool(HWND wnd, uTOOLINFO* ti, bool update = false);
+[[deprecated("No longer maintained.")]] bool uComboBox_SelectString(HWND combo, const char* src);
 
 namespace win32_helpers {
-void send_message_to_all_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARAM lp);
+
 void send_message_to_direct_children(HWND wnd_parent, UINT msg, WPARAM wp, LPARAM lp);
 int message_box(HWND wnd, const TCHAR* text, const TCHAR* caption, UINT type);
-bool tooltip_add_tool(HWND wnd, TOOLINFO* ti, bool update = false);
+
+[[deprecated("No longer maintained.")]] void send_message_to_all_children(
+    HWND wnd_parent, UINT msg, WPARAM wp, LPARAM lp);
+[[deprecated("No longer maintained.")]] bool tooltip_add_tool(HWND wnd, TOOLINFO* ti, bool update = false);
+
 }; // namespace win32_helpers
-
-
-#endif


### PR DESCRIPTION
This deprecates some old Win32 helpers which are no longer in use by Columns UI.

A couple of others are removed completely.