### PR TITLE
Tidy up project file and add public project file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ components for Columns UI.
 
 Refer to https://columns-ui-sdk.readthedocs.io for further documentation.
 
+This repo contains two project files:
+
+- `columns_ui-sdk-public.vcxproj` – this is the project file included in the SDK
+  download, which works out of the box with the foobar2000 SDK
+- `columns_ui-sdk.vcxproj` – this is the project file used by my components,
+  which uses the statically-linked CRT and customised intermediate and output
+  directories
+
 ## Building the docs
 
 1. [Install Python 3](https://www.python.org/downloads/)

--- a/columns_ui-sdk-public.vcxproj
+++ b/columns_ui-sdk-public.vcxproj
@@ -60,26 +60,9 @@
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration.ToLower())-$(Platform.ToLower())-$(PlatformToolset.ToLower())\$(ProjectName)\</IntDir>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>ui_extension.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
@@ -99,7 +82,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>ui_extension.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
@@ -125,7 +107,6 @@
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -147,7 +128,6 @@
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>

--- a/columns_ui-sdk-public.vcxproj.filters
+++ b/columns_ui-sdk-public.vcxproj.filters
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Panel API">
+      <UniqueIdentifier>{e15fcf9c-8637-43d0-98a1-0e78f81b8e2d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Helpers">
+      <UniqueIdentifier>{2022b9c3-c253-4235-97b9-90dac50f6f52}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="CUI">
+      <UniqueIdentifier>{f53abb3c-f2b1-4908-85d7-657f3e54b28b}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\columns_ui-sdk\base.h">
+      <Filter>Panel API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\buttons.h">
+      <Filter>Panel API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\menu.h">
+      <Filter>Panel API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\splitter.h">
+      <Filter>Panel API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\visualisation.h">
+      <Filter>Panel API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\window.h">
+      <Filter>Panel API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\window_host.h">
+      <Filter>Panel API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\win32_helpers.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\window_helper.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\columns_ui.h">
+      <Filter>CUI</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\columns_ui_appearance.h">
+      <Filter>CUI</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns_ui-sdk\ui_extension.h" />
+    <ClInclude Include="container_window_v3.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="container_uie_window_v3.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\columns_ui-sdk\win32_helpers.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\columns_ui-sdk\window_helper.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\columns_ui-sdk\columns_ui.cpp">
+      <Filter>CUI</Filter>
+    </ClCompile>
+    <ClCompile Include="..\columns_ui-sdk\ui_extension.cpp" />
+    <ClCompile Include="container_window_v3.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -4,7 +4,9 @@ Upgrading the SDK
 Version 7.0-beta.1
 ------------------
 
-The latest version of the Columns UI SDK requires Visual Studio 2022.
+This version of the Columns UI SDK requires Visual Studio 2022.
+
+The project file was also renamed ``columns_ui-sdk-public.vcxproj``.
 
 New in this version
 ~~~~~~~~~~~~~~~~~~~

--- a/scripts/make-sdk.cmd
+++ b/scripts/make-sdk.cmd
@@ -1,0 +1,2 @@
+del build\columns_ui-sdk.7z
+7z a build\columns_ui-sdk.7z *.cpp *.h LICENCE columns_ui-sdk-public.vcxproj columns_ui-sdk-public.vcxproj.filters -mx=7


### PR DESCRIPTION
This:

- tidies up the debug project configuration
- removes the inclusion of per-user property sheets as per https://docs.microsoft.com/en-gb/cpp/build/create-reusable-property-configurations
- adds a public project file more compatible with the foobar2000 SDK defaults
- adds a script to make an archive of the SDK for distribution