### PR TITLE
Add opt-out for WM_SETTINGCHANGE forwarding in container_window_v3

### DIFF
--- a/container_window_v3.cpp
+++ b/container_window_v3.cpp
@@ -68,7 +68,8 @@ LRESULT container_window_v3::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
     case WM_SETTINGCHANGE:
     case WM_SYSCOLORCHANGE:
     case WM_TIMECHANGE:
-        win32_helpers::send_message_to_direct_children(wnd, msg, wp, lp);
+        if (msg != WM_SETTINGCHANGE || m_config.forward_wm_settingchange)
+            win32_helpers::send_message_to_direct_children(wnd, msg, wp, lp);
         break;
     case WM_ERASEBKGND:
         if (m_config.use_transparent_background) {

--- a/container_window_v3.h
+++ b/container_window_v3.h
@@ -22,6 +22,14 @@ struct container_window_v3_config {
      */
     bool use_transparent_background{true};
     bool invalidate_children_on_move_or_resize{};
+
+    /**
+     * Whether to forward WM_SETTINGCHANGE messages to direct child windows.
+     *
+     * This should be set to false if a toolbar control is a direct child window,
+     * as they can misbehave when handling WM_SETTINGCHANGE.
+     */
+    bool forward_wm_settingchange{true};
     unsigned window_styles{WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS};
     unsigned extended_window_styles{WS_EX_CONTROLPARENT};
     unsigned class_styles{};


### PR DESCRIPTION
This adds an option to container_window_v3 to disable the forwarding of WM_SETTINGCHANGE messages to direct child windows.

This is because the Win32 toolbar control appears to misbehave when handling the message.