### PR TITLE
Avoid crash in container_uie_window_v3 if destroyed twice

### DIFF
--- a/container_uie_window_v3.h
+++ b/container_uie_window_v3.h
@@ -41,8 +41,11 @@ public:
 
     void destroy_window() final
     {
-        m_window->destroy();
-        m_window.reset();
+        if (m_window) {
+            m_window->destroy();
+            m_window.reset();
+        }
+
         m_host.release();
     }
 

--- a/container_window_v3.cpp
+++ b/container_window_v3.cpp
@@ -29,7 +29,9 @@ HWND container_window_v3::create(HWND wnd_parent)
 
 void container_window_v3::destroy() const
 {
-    DestroyWindow(m_wnd);
+    if (m_wnd)
+        DestroyWindow(m_wnd);
+
     if (s_window_count[m_config.class_name] == 0) {
         deregister_class();
     }


### PR DESCRIPTION
This avoids a crash in `container_uie_window_v3_t::destroy_window()` if it is called when the window has already been destroyed, or was never created.

It also makes a similar improvement to `container_window_v3::destroy()`.