### PR TITLE
Fix unwanted deprecation warning

### DIFF
--- a/window_helper.h
+++ b/window_helper.h
@@ -146,8 +146,8 @@ public:
 public:
 };
 
-#pragma warning(suppress : 4996)
 class [[deprecated("Use uie::container_window_v3")]] container_window_autorelease_t
+#pragma warning(suppress : 4996)
     : public container_window_release_t {
 public:
     container_window_autorelease_t();


### PR DESCRIPTION
This moves a `#pragma warning(suppress : 4996)` to the correct line after the code was reformatted in 68d6e8e13a39127d0e8bd4bd18770260a9622c50.