### PR TITLE
Remove project directory from source file paths in project file

### DIFF
--- a/columns_ui-sdk-public.vcxproj
+++ b/columns_ui-sdk-public.vcxproj
@@ -141,26 +141,26 @@
     <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\columns_ui-sdk\base.h" />
-    <ClInclude Include="..\columns_ui-sdk\buttons.h" />
-    <ClInclude Include="..\columns_ui-sdk\menu.h" />
-    <ClInclude Include="..\columns_ui-sdk\splitter.h" />
-    <ClInclude Include="..\columns_ui-sdk\visualisation.h" />
-    <ClInclude Include="..\columns_ui-sdk\window.h" />
-    <ClInclude Include="..\columns_ui-sdk\window_host.h" />
-    <ClInclude Include="..\columns_ui-sdk\win32_helpers.h" />
-    <ClInclude Include="..\columns_ui-sdk\window_helper.h" />
-    <ClInclude Include="..\columns_ui-sdk\columns_ui.h" />
-    <ClInclude Include="..\columns_ui-sdk\columns_ui_appearance.h" />
-    <ClInclude Include="..\columns_ui-sdk\ui_extension.h" />
+    <ClInclude Include="base.h" />
+    <ClInclude Include="buttons.h" />
+    <ClInclude Include="menu.h" />
+    <ClInclude Include="splitter.h" />
+    <ClInclude Include="visualisation.h" />
+    <ClInclude Include="window.h" />
+    <ClInclude Include="window_host.h" />
+    <ClInclude Include="win32_helpers.h" />
+    <ClInclude Include="window_helper.h" />
+    <ClInclude Include="columns_ui.h" />
+    <ClInclude Include="columns_ui_appearance.h" />
+    <ClInclude Include="ui_extension.h" />
     <ClInclude Include="container_uie_window_v3.h" />
     <ClInclude Include="container_window_v3.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\columns_ui-sdk\win32_helpers.cpp" />
-    <ClCompile Include="..\columns_ui-sdk\window_helper.cpp" />
-    <ClCompile Include="..\columns_ui-sdk\columns_ui.cpp" />
-    <ClCompile Include="..\columns_ui-sdk\ui_extension.cpp">
+    <ClCompile Include="win32_helpers.cpp" />
+    <ClCompile Include="window_helper.cpp" />
+    <ClCompile Include="columns_ui.cpp" />
+    <ClCompile Include="ui_extension.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/columns_ui-sdk-public.vcxproj.filters
+++ b/columns_ui-sdk-public.vcxproj.filters
@@ -12,40 +12,40 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\columns_ui-sdk\base.h">
+    <ClInclude Include="base.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\buttons.h">
+    <ClInclude Include="buttons.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\menu.h">
+    <ClInclude Include="menu.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\splitter.h">
+    <ClInclude Include="splitter.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\visualisation.h">
+    <ClInclude Include="visualisation.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\window.h">
+    <ClInclude Include="window.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\window_host.h">
+    <ClInclude Include="window_host.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\win32_helpers.h">
+    <ClInclude Include="win32_helpers.h">
       <Filter>Helpers</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\window_helper.h">
+    <ClInclude Include="window_helper.h">
       <Filter>Helpers</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\columns_ui.h">
+    <ClInclude Include="columns_ui.h">
       <Filter>CUI</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\columns_ui_appearance.h">
+    <ClInclude Include="columns_ui_appearance.h">
       <Filter>CUI</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\ui_extension.h" />
+    <ClInclude Include="ui_extension.h" />
     <ClInclude Include="container_window_v3.h">
       <Filter>Helpers</Filter>
     </ClInclude>
@@ -54,16 +54,16 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\columns_ui-sdk\win32_helpers.cpp">
+    <ClCompile Include="win32_helpers.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
-    <ClCompile Include="..\columns_ui-sdk\window_helper.cpp">
+    <ClCompile Include="window_helper.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
-    <ClCompile Include="..\columns_ui-sdk\columns_ui.cpp">
+    <ClCompile Include="columns_ui.cpp">
       <Filter>CUI</Filter>
     </ClCompile>
-    <ClCompile Include="..\columns_ui-sdk\ui_extension.cpp" />
+    <ClCompile Include="ui_extension.cpp" />
     <ClCompile Include="container_window_v3.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>

--- a/columns_ui-sdk.vcxproj
+++ b/columns_ui-sdk.vcxproj
@@ -161,26 +161,26 @@
     <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\columns_ui-sdk\base.h" />
-    <ClInclude Include="..\columns_ui-sdk\buttons.h" />
-    <ClInclude Include="..\columns_ui-sdk\menu.h" />
-    <ClInclude Include="..\columns_ui-sdk\splitter.h" />
-    <ClInclude Include="..\columns_ui-sdk\visualisation.h" />
-    <ClInclude Include="..\columns_ui-sdk\window.h" />
-    <ClInclude Include="..\columns_ui-sdk\window_host.h" />
-    <ClInclude Include="..\columns_ui-sdk\win32_helpers.h" />
-    <ClInclude Include="..\columns_ui-sdk\window_helper.h" />
-    <ClInclude Include="..\columns_ui-sdk\columns_ui.h" />
-    <ClInclude Include="..\columns_ui-sdk\columns_ui_appearance.h" />
-    <ClInclude Include="..\columns_ui-sdk\ui_extension.h" />
+    <ClInclude Include="base.h" />
+    <ClInclude Include="buttons.h" />
+    <ClInclude Include="menu.h" />
+    <ClInclude Include="splitter.h" />
+    <ClInclude Include="visualisation.h" />
+    <ClInclude Include="window.h" />
+    <ClInclude Include="window_host.h" />
+    <ClInclude Include="win32_helpers.h" />
+    <ClInclude Include="window_helper.h" />
+    <ClInclude Include="columns_ui.h" />
+    <ClInclude Include="columns_ui_appearance.h" />
+    <ClInclude Include="ui_extension.h" />
     <ClInclude Include="container_uie_window_v3.h" />
     <ClInclude Include="container_window_v3.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\columns_ui-sdk\win32_helpers.cpp" />
-    <ClCompile Include="..\columns_ui-sdk\window_helper.cpp" />
-    <ClCompile Include="..\columns_ui-sdk\columns_ui.cpp" />
-    <ClCompile Include="..\columns_ui-sdk\ui_extension.cpp">
+    <ClCompile Include="win32_helpers.cpp" />
+    <ClCompile Include="window_helper.cpp" />
+    <ClCompile Include="columns_ui.cpp" />
+    <ClCompile Include="ui_extension.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/columns_ui-sdk.vcxproj.filters
+++ b/columns_ui-sdk.vcxproj.filters
@@ -12,40 +12,40 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\columns_ui-sdk\base.h">
+    <ClInclude Include="base.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\buttons.h">
+    <ClInclude Include="buttons.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\menu.h">
+    <ClInclude Include="menu.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\splitter.h">
+    <ClInclude Include="splitter.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\visualisation.h">
+    <ClInclude Include="visualisation.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\window.h">
+    <ClInclude Include="window.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\window_host.h">
+    <ClInclude Include="window_host.h">
       <Filter>Panel API</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\win32_helpers.h">
+    <ClInclude Include="win32_helpers.h">
       <Filter>Helpers</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\window_helper.h">
+    <ClInclude Include="window_helper.h">
       <Filter>Helpers</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\columns_ui.h">
+    <ClInclude Include="columns_ui.h">
       <Filter>CUI</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\columns_ui_appearance.h">
+    <ClInclude Include="columns_ui_appearance.h">
       <Filter>CUI</Filter>
     </ClInclude>
-    <ClInclude Include="..\columns_ui-sdk\ui_extension.h" />
+    <ClInclude Include="ui_extension.h" />
     <ClInclude Include="container_window_v3.h">
       <Filter>Helpers</Filter>
     </ClInclude>
@@ -54,16 +54,16 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\columns_ui-sdk\win32_helpers.cpp">
+    <ClCompile Include="win32_helpers.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
-    <ClCompile Include="..\columns_ui-sdk\window_helper.cpp">
+    <ClCompile Include="window_helper.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
-    <ClCompile Include="..\columns_ui-sdk\columns_ui.cpp">
+    <ClCompile Include="columns_ui.cpp">
       <Filter>CUI</Filter>
     </ClCompile>
-    <ClCompile Include="..\columns_ui-sdk\ui_extension.cpp" />
+    <ClCompile Include="ui_extension.cpp" />
     <ClCompile Include="container_window_v3.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -1,6 +1,16 @@
 Upgrading the SDK
 =================
 
+Development version
+-------------------
+
+Bug fixes
+~~~~~~~~~
+
+The project file was updated to remove ``..\columns_ui-sdk`` from referenced
+file paths. This makes it possible for names other than ``columns_ui-sdk``
+to be used for the directory containing the Columns UI SDK.
+
 Version 7.0.0
 -------------
 


### PR DESCRIPTION
Some source files were referenced using `..\columns_ui-sdk\` in the project file. This was redundant, and prevented a different directory name being used for the project.