### PR TITLE
Add preliminary font_manager_v3 interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ debug-*/
 doxygen/
 .idea/
 vcpkg_installed/
+.venv/

--- a/base.h
+++ b/base.h
@@ -108,7 +108,7 @@ public:
     virtual bool have_config_popup() const { return false; }
 
     /**
-     * \brief Displays a modal configuartion dialog
+     * \brief Displays a modal configuration dialog
      *
      * \param [in]    wnd_parent    The window to use as the owner window for your configuration dialog
      *

--- a/columns_ui-sdk.vcxproj
+++ b/columns_ui-sdk.vcxproj
@@ -163,6 +163,7 @@
   <ItemGroup>
     <ClInclude Include="base.h" />
     <ClInclude Include="buttons.h" />
+    <ClInclude Include="font_manager_v3.h" />
     <ClInclude Include="menu.h" />
     <ClInclude Include="splitter.h" />
     <ClInclude Include="visualisation.h" />

--- a/columns_ui-sdk.vcxproj.filters
+++ b/columns_ui-sdk.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClInclude Include="container_uie_window_v3.h">
       <Filter>Helpers</Filter>
     </ClInclude>
+    <ClInclude Include="font_manager_v3.h">
+      <Filter>CUI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="win32_helpers.cpp">

--- a/columns_ui.cpp
+++ b/columns_ui.cpp
@@ -62,6 +62,15 @@ const GUID fonts::client::class_guid = {0x3fbcc2b0, 0x978e, 0x406f, {0xa4, 0x46,
 
 #endif
 
+namespace fonts {
+
+#ifndef CUI_SDK_DWRITE_DISABLED
+const GUID font::class_guid{0x907a8df2, 0xc398, 0x402b, {0x83, 0x1f, 0x03, 0x11, 0xf5, 0xa9, 0x8f, 0x19}};
+const GUID manager_v3::class_guid{0xdb18291d, 0x8013, 0x4f32, {0x96, 0x4b, 0x37, 0x77, 0xfd, 0xba, 0x56, 0x90}};
+#endif
+
+} // namespace fonts
+
 void cui::fcl::dataset::get_data_to_array(pfc::array_t<uint8_t>& p_data, t_uint32 type, t_export_feedback& feedback,
     abort_callback& p_abort, bool b_reset) const
 {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 breathe~=4.34
-sphinx~=5.0
+sphinx~=7.0
 takao

--- a/font_manager_v3.h
+++ b/font_manager_v3.h
@@ -1,0 +1,129 @@
+#pragma once
+
+namespace cui::fonts {
+
+#if NTDDI_VERSION >= 0x0A000004
+static_assert(sizeof(DWRITE_FONT_AXIS_VALUE) == 8);
+using AxisValue = DWRITE_FONT_AXIS_VALUE;
+#else
+struct AxisValue {
+    uint32_t axis_tag;
+    float value;
+};
+#endif
+
+struct rendering_options {
+    DWRITE_RENDERING_MODE rendering_mode{DWRITE_RENDERING_MODE_DEFAULT};
+    bool force_greyscale_antialiasing{};
+};
+
+enum class FontFamilyModel {
+    /**
+     * Returns the typographic font family name if known,
+     * otherwise the weight-stretch-style family name.
+     */
+    Automatic = 0,
+    /**
+     * Requests the weight-stretch-style family name.
+     * May return an empty string if not known.
+     */
+    WeightStretchStyle = 1,
+    /**
+     * Requests the typographic family name.
+     * May return an empty string if not known.
+     */
+    Typographic = 2,
+};
+
+/**
+ * Defines a font, as configured in Columns UI Colours and fonts preferences.
+ *
+ * \note Part of the preliminary DirectWrite-friendly manager_v3 interface.
+ *       Subject to change before the final Columns UI 3.0.0 release.
+ *
+ * The recommended methods to use are create_text_format() and get_rendering_options().
+ * However, access to the underlying data is also provided for less common use cases.
+ */
+class NOVTABLE font : public service_base {
+public:
+    [[nodiscard]] virtual const wchar_t* family_name(
+        FontFamilyModel font_family_model = FontFamilyModel::Automatic) noexcept
+        = 0;
+    [[nodiscard]] virtual DWRITE_FONT_WEIGHT weight() noexcept = 0;
+    [[nodiscard]] virtual DWRITE_FONT_STRETCH stretch() noexcept = 0;
+    [[nodiscard]] virtual DWRITE_FONT_STYLE style() noexcept = 0;
+
+    /**
+     * Get the font size, in DIP units.
+     */
+    [[nodiscard]] virtual float size() noexcept = 0;
+
+    /**
+     * Get the number of configured font axes. May be zero, in which case
+     * the weight-stretch-style values should be used.
+     */
+    [[nodiscard]] virtual size_t axis_count() const noexcept = 0;
+
+    /**
+     * Get an axis value.
+     *
+     * \param index Axis index. Must be in the range 0 <= index < axis_count().
+     * \throws std::out_of_range on invalid index
+     */
+    [[nodiscard]] virtual AxisValue axis_value(size_t index) const = 0;
+
+    /**
+     * Get a GDI-compatible LOGFONT for this font.
+     *
+     * Note that this is the closest equivalent as GDI does not support
+     * modern font features.
+     */
+    [[nodiscard]] virtual LOGFONT log_font() noexcept = 0;
+
+    /**
+     * Create a DirectWrite text format for this font.
+     */
+    [[nodiscard]] virtual pfc::com_ptr_t<IDWriteTextFormat> create_text_format(
+        const wchar_t* locale_name = L"") noexcept
+        = 0;
+
+    /**
+     * Retrieves the rendering mode configured in Columns UI preferences.
+     */
+    [[nodiscard]] virtual DWRITE_RENDERING_MODE rendering_mode() noexcept = 0;
+
+    /**
+     * Retrieves the value of the 'Force greyscale antialiasing' setting in
+     * Columns UI preferences.
+     */
+    [[nodiscard]] virtual bool force_greyscale_antialiasing() noexcept = 0;
+
+    rendering_options get_rendering_options() { return {rendering_mode(), force_greyscale_antialiasing()}; }
+
+#ifdef __WIL_COM_INCLUDED
+    wil::com_ptr_t<IDWriteTextFormat> create_wil_text_format(const wchar_t* locale_name = L"")
+    {
+        wil::com_ptr_t<IDWriteTextFormat> text_format;
+        text_format.attach(create_text_format(locale_name).detach());
+        return text_format;
+    }
+#endif
+
+    FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(font);
+};
+
+/**
+ * Preliminary DirectWrite-friendly manager_v3 interface.
+ *
+ * \note Part of the preliminary DirectWrite-friendly manager_v3 interface.
+ *       Subject to change before the final Columns UI 3.0.0 release.
+ */
+class NOVTABLE manager_v3 : public service_base {
+public:
+    [[nodiscard]] virtual font::ptr get_client_font(GUID id) const = 0;
+    virtual void set_client_font_size(GUID id, float size) = 0;
+
+    FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(manager_v3);
+};
+
+} // namespace cui::fonts

--- a/ui_extension.h
+++ b/ui_extension.h
@@ -3,6 +3,10 @@
 
 #define UI_EXTENSION_VERSION "7.0.0"
 
+#if !__has_include(<dwrite_3.h>)
+#define CUI_SDK_DWRITE_DISABLED
+#endif
+
 #include <algorithm>
 #include <memory>
 #include <unordered_map>
@@ -12,6 +16,9 @@
 // Included first, because pfc.h includes winsock2.h
 #include "../pfc/pfc.h"
 
+#ifndef CUI_SDK_DWRITE_DISABLED
+#include <dwrite_3.h>
+#endif
 #include <shlwapi.h>
 
 #include "../foobar2000/SDK/foobar2000-lite.h"
@@ -148,6 +155,10 @@ namespace ui_extension = uie;
 #include "buttons.h"
 #include "columns_ui.h"
 #include "columns_ui_appearance.h"
+
+#ifndef CUI_SDK_DWRITE_DISABLED
+#include "font_manager_v3.h"
+#endif
 
 namespace ui_extension = uie;
 namespace columns_ui = cui;


### PR DESCRIPTION
This adds a preliminary font_manager_v3 interface that supports new font features available in Columns UI 3.0.0 and is designed with DirectWrite in mind.

Updated font helpers are not included as yet.