### PR TITLE
Mark callback functions as noexcept

### DIFF
--- a/container_window_v3.cpp
+++ b/container_window_v3.cpp
@@ -37,7 +37,7 @@ void container_window_v3::destroy() const
     }
 }
 
-LRESULT container_window_v3::s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT container_window_v3::s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     container_window_v3* self{};
 

--- a/container_window_v3.h
+++ b/container_window_v3.h
@@ -84,7 +84,7 @@ public:
     void deregister_class() const;
 
 private:
-    static LRESULT WINAPI s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     void register_class() const;

--- a/window_helper.cpp
+++ b/window_helper.cpp
@@ -87,7 +87,7 @@ void container_window::destroy()
 }
 
 #pragma warning(suppress : 4996)
-LRESULT WINAPI container_window::window_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI container_window::window_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     container_window* p_this;
 

--- a/window_helper.h
+++ b/window_helper.h
@@ -104,7 +104,7 @@ public:
     void destroy(); // if destroying someother way, you should make sure you call class_release() after destroying the
                     // window (e.g. call it on app-shutdown)
 
-    static LRESULT WINAPI window_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI window_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
 
     HWND get_wnd() const;
 
@@ -126,7 +126,7 @@ public:
         void deregister_window(container_window_release_t& ptr) { m_windows.remove_item(&ptr); }
 
     private:
-        void on_quit() override
+        void on_quit() noexcept override
         {
             t_size i = m_windows.get_count();
             for (; i; i--) {


### PR DESCRIPTION
This marks various callback functions passed to the Win32 API and to foobar2000 as noexcept.

This is as they aren't allowed to throw C++ exceptions. `noexcept` will result in `std::terminate` being called if that happens.
