### PR TITLE
Add additional DirectWrite helpers and update docs

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2186,7 +2186,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = _MSC_VER=1935 CUI_SDK_DWRITE_ENABLED DWRITE_2_H_INCLUDED
+PREDEFINED             = _MSC_VER=1935 CUI_SDK_DWRITE_ENABLED DWRITE_2_H_INCLUDED _D2D1_H_
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/columns_ui-sdk-public.vcxproj
+++ b/columns_ui-sdk-public.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="buttons.h" />
     <ClInclude Include="callback.h" />
     <ClInclude Include="colours.h" />
+    <ClInclude Include="dwrite_utils.h" />
     <ClInclude Include="fonts.h" />
     <ClInclude Include="font_manager_v3.h" />
     <ClInclude Include="font_utils.h" />
@@ -163,6 +164,7 @@
   <ItemGroup>
     <ClCompile Include="callback.cpp" />
     <ClCompile Include="colours.cpp" />
+    <ClCompile Include="dwrite_utils.cpp" />
     <ClCompile Include="fonts.cpp" />
     <ClCompile Include="font_manager_v3.cpp" />
     <ClCompile Include="font_utils.cpp" />

--- a/columns_ui-sdk.vcxproj
+++ b/columns_ui-sdk.vcxproj
@@ -165,6 +165,7 @@
     <ClInclude Include="buttons.h" />
     <ClInclude Include="callback.h" />
     <ClInclude Include="colours.h" />
+    <ClInclude Include="dwrite_utils.h" />
     <ClInclude Include="fonts.h" />
     <ClInclude Include="font_manager_v3.h" />
     <ClInclude Include="font_utils.h" />
@@ -183,6 +184,7 @@
   <ItemGroup>
     <ClCompile Include="callback.cpp" />
     <ClCompile Include="colours.cpp" />
+    <ClCompile Include="dwrite_utils.cpp" />
     <ClCompile Include="fonts.cpp" />
     <ClCompile Include="font_manager_v3.cpp" />
     <ClCompile Include="font_utils.cpp" />

--- a/columns_ui-sdk.vcxproj.filters
+++ b/columns_ui-sdk.vcxproj.filters
@@ -64,6 +64,9 @@
     <ClInclude Include="callback.h">
       <Filter>CUI</Filter>
     </ClInclude>
+    <ClInclude Include="dwrite_utils.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="win32_helpers.cpp">
@@ -93,6 +96,9 @@
     </ClCompile>
     <ClCompile Include="callback.cpp">
       <Filter>CUI</Filter>
+    </ClCompile>
+    <ClCompile Include="dwrite_utils.cpp">
+      <Filter>Helpers</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/docs/source/appearance/directwrite-utilities.rst
+++ b/docs/source/appearance/directwrite-utilities.rst
@@ -1,0 +1,4 @@
+DirectWrite utilities
+=====================
+
+.. doxygennamespace:: cui::dwrite_utils

--- a/docs/source/toc.rst
+++ b/docs/source/toc.rst
@@ -28,6 +28,7 @@
 
     appearance/colours
     appearance/fonts
+    appearance/directwrite-utilities
 
 .. toctree::
     :hidden:

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -4,24 +4,43 @@ Upgrading the SDK
 Version 8.0.0-beta.1
 --------------------
 
-New in this version
-~~~~~~~~~~~~~~~~~~~
+Highlights
+~~~~~~~~~~
 
 This version adds a new, experimental :class:`cui::fonts::manager_v3` service
 with DirectWrite support.
 
-The following new named constants were added:
+New in this version
+~~~~~~~~~~~~~~~~~~~
+
+The following services were added:
+
+- :class:`cui::fonts::manager_v3`
+- :class:`cui::fonts::rendering_options`
+- :class:`cui::fonts::font`
+
+The following enumerations were added:
+
+- :class:`cui::fonts::font_family_model`
+
+The following exceptions were added:
+
+- :class:`cui::fonts::exception_font_client_not_found`
+
+The following named constants were added:
 
 - :var:`cui::fonts::items_font_id`
 - :var:`cui::fonts::labels_font_id`
 
-The following new font helpers were also added:
+The following helpers were added:
 
 - :func:`cui::fonts::get_log_font()`
 - :func:`cui::fonts::get_log_font_with_fallback()`
 - :func:`cui::fonts::create_hfont_with_fallback()`
 - :func:`cui::fonts::get_font()`
 - :func:`cui::fonts::on_common_font_changed()`
+- :func:`cui::dwrite_utils::get_monitor_for_window()`
+- :func:`cui::dwrite_utils::create_custom_rendering_params()`
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/using-fonts.rst
+++ b/docs/source/using-fonts.rst
@@ -26,7 +26,7 @@ Querying fonts
 GDI
 ~~~
 
-:func:`cui::fonts::create_hfont_with_fallback()` can be used to create to an
+:func:`cui::fonts::create_hfont_with_fallback()` can be used to create an
 ``HFONT`` for a particular font client, while
 :func:`cui::fonts::get_log_font_with_fallback()` and can be used to get the
 ``LOGFONT`` structure for a particular font client. There are also various other
@@ -56,9 +56,144 @@ Common fonts
 ~~~~~~~~~~~~
 
 It’s also possible to pass the ID of a common font (i.e.
-``cui::fonts::items_font_id`` or ``cui::fonts::labels_font_id``) rather than the
-ID of a font client to the functions mentioned in the previous two sections.
-However, given the ease of implementing a font client to add a custom entry,
-it’s not generally recommended to use the common fonts directly.
+:var:`cui::fonts::items_font_id` or :var:`cui::fonts::labels_font_id`) rather
+than the ID of a font client to the functions mentioned in the previous two
+sections. However, given the ease of implementing a font client to add a custom
+entry, it’s not generally recommended to use the common fonts directly.
+
+Rendering text using DirectWrite
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Rendering using Direct2D
+++++++++++++++++++++++++
+
+Below is a simplified guide to using the font API with Direct2D. Error handling
+is omitted, as is general Direct2D set-up and rendering code.
+
+In your own code, using the `error handling helpers from the Windows
+Implementation Libraries`_ is recommended.
+
+Refer to the Direct2D documentation for more general information on how to use
+Direct2D (for example, the `Create a simple Direct2D application`_ article).
+
+1. Create a text format and query rendering options
+...................................................
+
+When your panel window is created, and when the
+:func:`cui::fonts::client::on_font_changed()` method of your font client is
+called, create or recreate a DirectWrite text format and query the rendering
+options:
+
+.. code-block:: cpp
+
+    struct TextFormatWrapper
+    {
+        pfc::com_ptr_t<IDWriteTextFormat> text_format;
+        cui::fonts::rendering_options::ptr rendering_options;
+    };
+
+    TextFormatWrapper create_text_format()
+    {
+        TextFormatWrapper text_format_wrapper;
+        const auto font = cui::fonts::get_font(my_font_id);
+
+        if (font) {
+            text_format_wrapper.text_format = font->create_text_format();
+            text_format_wrapper.rendering_options = font->rendering_options();
+        }
+
+        if (!text_format_wrapper.text_format.is_valid()) {
+            // Implement fallback path here – for example, using
+            // cui::fonts::get_log_font_with_fallback()
+            // and IDWriteGdiInterop
+        }
+
+        text_format_wrapper.text_format->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
+        text_format_wrapper.text_format->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+
+        return text_format_wrapper;
+    }
+
+2. Create a text layout
+.......................
+
+Whenever the text being rendered changes, create a new DirectWrite text layout:
+
+.. code-block:: cpp
+
+    pfc::com_ptr_t<IDWriteTextLayout> create_text_layout(IDWriteFactory* factory,
+        const TextFormatWrapper& text_format_wrapper)
+    {
+        HRESULT hr{};
+        pfc::com_ptr_t<IDWriteTextLayout> text_layout;
+
+        if (text_format_wrapper.rendering_options->use_gdi_compatible_layout()) {
+            const auto use_gdi_natural = text_format_wrapper.rendering_options->use_gdi_natural();
+            hr = factory->CreateGdiCompatibleTextLayout(
+                /* arguments omitted */, use_gdi_natural, text_layout.receive_ptr());
+        } else {
+            hr = factory->CreateTextLayout(/* arguments omitted */, text_layout.receive_ptr());
+        }
+
+        if (FAILED(hr)) {
+            // Handle error
+        }
+
+        return text_layout;
+    }
+
+3. Render text using Direct2D
+.............................
+
+Within your Direct2D rendering logic, render the text layout with the correct
+rendering parameters:
+
+.. code-block:: cpp
+
+    void render_text_layout(IDWriteFactory* factory, ID2D1RenderTarget* render_target, IDWriteTextLayout* layout, HWND wnd,
+        const cui::fonts::rendering_options::ptr& rendering_options)
+    {
+        HRESULT hr{};
+        const auto monitor = cui::dwrite_utils::get_monitor_for_window(wnd);
+
+        pfc::com_ptr_t<IDWriteRenderingParams> rendering_params;
+        hr = dwrite_utils::create_custom_rendering_params(factory, monitor, rendering_options->rendering_mode(),
+            rendering_options->force_greyscale_antialiasing(), rendering_params.receive_ptr());
+
+        if (FAILED(hr)) {
+            // Handle error
+        }
+
+        render_target->SetTextRenderingParams(rendering_params.get_ptr());
+        render_target->SetTextAntialiasMode(rendering_options->d2d_text_antialiasing_mode());
+
+        // Note: D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT is only supported on Windows 8.1 and newer.
+        // Do not set the flag on older versions of Windows, as it will cause rendering to fail.
+        // Check for support of D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT by e.g. querying the render
+        // target for the ID2D1DeviceContext1 interface.
+        const auto draw_text_opts = rendering_options->use_colour_glyphs() ? D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT
+            : D2D1_DRAW_TEXT_OPTIONS_NONE;
+        render_target->DrawTextLayout(/* origin */, layout, /* D2D brush */, draw_text_opts);
+    }
+
+Rendering directly to a GDI device context
+++++++++++++++++++++++++++++++++++++++++++
+
+If you wish to render text using DirectWrite directly to a GDI device context
+(without using Direct2D), you’ll need to implement a custom IDWriteTextRenderer_
+object.
+
+See `Render to a GDI surface`_ and the `GdiInterop sample`_ for examples of
+this.
+
+.. _create a simple direct2d application: https://learn.microsoft.com/en-gb/windows/win32/direct2d/direct2d-quickstart
+
+.. _error handling helpers from the windows implementation libraries: https://github.com/microsoft/wil/wiki/Error-handling-helpers
+
+.. _gdiinterop sample: https://github.com/microsoft/Windows-classic-samples/tree/main/Samples/Win7Samples/multimedia/DirectWrite/GdiInterop
+
+.. _idwritetextrenderer: https://learn.microsoft.com/en-gb/windows/win32/api/dwrite/nn-dwrite-idwritetextrenderer
+
+.. _render to a gdi surface: https://learn.microsoft.com/en-gb/windows/win32/directwrite/render-to-a-gdi-surface
 
 .. _the console panel source: https://github.com/reupen/console_panel/blob/38983f68cea0bb6843ce8401f8601bb0651bc8c4/foo_uie_console/main.cpp#L624-L659

--- a/dwrite_utils.cpp
+++ b/dwrite_utils.cpp
@@ -1,0 +1,33 @@
+#include "ui_extension.h"
+
+#if CUI_SDK_DWRITE_ENABLED
+
+namespace cui::dwrite_utils {
+
+HRESULT create_custom_rendering_params(IDWriteFactory* factory, HMONITOR monitor, DWRITE_RENDERING_MODE rendering_mode,
+    bool force_greyscale_antialiasing, IDWriteRenderingParams** rendering_params)
+{
+    pfc::com_ptr_t<IDWriteRenderingParams> monitor_rendering_params;
+    if (HRESULT hr{};
+        FAILED(hr = factory->CreateMonitorRenderingParams(monitor, monitor_rendering_params.receive_ptr())))
+        return hr;
+
+    return factory->CreateCustomRenderingParams(monitor_rendering_params->GetGamma(),
+        monitor_rendering_params->GetEnhancedContrast(), monitor_rendering_params->GetClearTypeLevel(),
+        force_greyscale_antialiasing ? DWRITE_PIXEL_GEOMETRY_FLAT : monitor_rendering_params->GetPixelGeometry(),
+        rendering_mode, rendering_params);
+}
+
+HMONITOR get_monitor_for_window(HWND wnd)
+{
+    const auto root_window = GetAncestor(wnd, GA_ROOT);
+
+    if (!root_window)
+        return nullptr;
+
+    return MonitorFromWindow(root_window, MONITOR_DEFAULTTONEAREST);
+}
+
+} // namespace cui::dwrite_utils
+
+#endif

--- a/dwrite_utils.h
+++ b/dwrite_utils.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace cui::dwrite_utils {
+/**
+ * Get the HMONITOR to use with `create_custom_rendering_params()` for an HWND.
+ *
+ * @param wnd The HWND that is rendering text using DirectWrite
+ * @return HMONITOR of the root window associated with the HWND, or `nullptr` on failure
+ */
+HMONITOR get_monitor_for_window(HWND wnd);
+
+/**
+ * Create DirectWrite rendering params for a monitor and specific rendering options.
+ *
+ * @param factory Pre-created DirectWrite factory
+ * @param monitor Monitor handle returned by `get_monitor_for_window()`
+ * @param rendering_mode Rendering mode returned by `cui::fonts::rendering_options::rendering_mode()`
+ * @param force_greyscale_antialiasing Flag returned by `cui::fonts::rendering_options::force_greyscale_antialiasing()`
+ * @param rendering_params Receives a pointer to the created IDWriteRenderingParams on success
+ * @return HRESULT indicating success or failure code
+ */
+HRESULT create_custom_rendering_params(IDWriteFactory* factory, HMONITOR monitor, DWRITE_RENDERING_MODE rendering_mode,
+    bool force_greyscale_antialiasing, IDWriteRenderingParams** rendering_params);
+
+} // namespace cui::dwrite_utils

--- a/ui_extension.h
+++ b/ui_extension.h
@@ -19,6 +19,7 @@
 
 #if CUI_SDK_DWRITE_ENABLED
 #include <dwrite_3.h>
+#include <d2d1.h>
 #endif
 #include <shlwapi.h>
 
@@ -161,6 +162,7 @@ namespace ui_extension = uie;
 
 #if CUI_SDK_DWRITE_ENABLED
 #include "font_manager_v3.h"
+#include "dwrite_utils.h"
 #endif
 
 #include "font_utils.h"


### PR DESCRIPTION
This expands the provided DirectWrite helpers to make it clearer how the rendering options are meant to be used.

The documentation has also been updated to add some more detailed examples of using the DirectWrite parts of the API to render text.