### PR TITLE
Update columns_ui-sdk-public.vcxproj.filters

### DIFF
--- a/columns_ui-sdk-public.vcxproj.filters
+++ b/columns_ui-sdk-public.vcxproj.filters
@@ -64,6 +64,9 @@
     <ClInclude Include="callback.h">
       <Filter>CUI</Filter>
     </ClInclude>
+    <ClInclude Include="dwrite_utils.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="win32_helpers.cpp">
@@ -93,6 +96,9 @@
     </ClCompile>
     <ClCompile Include="callback.cpp">
       <Filter>CUI</Filter>
+    </ClCompile>
+    <ClCompile Include="dwrite_utils.cpp">
+      <Filter>Helpers</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In a recent update, dwrite_utils.h/cpp were included in the main filters.vcxproj but omitted from the public version.