### PR TITLE
Prepare for 8.0.0 release

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-breathe~=4.34
-sphinx~=7.0
+breathe~=4.36
+sphinx~=8.2
 takao

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -1,6 +1,12 @@
 Upgrading the SDK
 =================
 
+Version 8.0.0
+-------------
+
+:class:`cui::fonts::manager_v3` and related services are no longer marked
+experimental.
+
 Version 8.0.0-rc.1
 ------------------
 

--- a/docs/source/using-fonts.rst
+++ b/docs/source/using-fonts.rst
@@ -1,12 +1,12 @@
 Using fonts
 ===========
 
-Columns UI features centralised configuration of fonts on its Font preferences
+Columns UI features centralised configuration of fonts on its Fonts preferences
 page. This allows fonts for different parts of the UI to be configured in one
 place.
 
-Third-party panel components can add their own entries to the Font preferences
-page and they can query fonts that have configured.
+Third-party panel components can add their own entries to the Fonts preferences
+page and they can query the current configuration.
 
 Adding a new entry
 ------------------
@@ -35,8 +35,8 @@ utility functions for other scenarios in the :cpp:type:`cui::fonts` namespace.
 DirectWrite
 ~~~~~~~~~~~
 
-Panels using DirectWrite can use the experimental :func:`cui::fonts::get_font()`
-function to retrieve a :class:`cui::fonts::font` instance. The
+Panels using DirectWrite can use :func:`cui::fonts::get_font()` to retrieve a
+:class:`cui::fonts::font` instance. The
 :func:`cui::fonts::font::create_text_format()` member function can then be
 called to create an ``IDWriteTextFormat`` object.
 
@@ -44,9 +44,7 @@ You should also apply the rendering options returned by
 :func:`cui::fonts::font::rendering_options()` when rendering text using the text
 format.
 
-Note that :func:`cui::fonts::get_font()` requires Columns UI 3.0.0 beta 1 or
-later, and compatibility may be broken before the final Columns UI 3.0.0
-release.
+Note that :func:`cui::fonts::get_font()` requires Columns UI 3.0.0 or later.
 
 If a compatible version of Columns UI isn’t installed,
 :func:`cui::fonts::get_font()` will return an empty ``std::optional``. Fallback

--- a/font_manager_v3.h
+++ b/font_manager_v3.h
@@ -35,8 +35,7 @@ enum class font_family_model {
 /**
  * Defines text rendering options, as configured in Columns UI Colours and fonts preferences.
  *
- * \note Part of the preliminary DirectWrite-friendly manager_v3 interface.
- *       Subject to change before the final Columns UI 3.0.0 release.
+ * \note Added in Columns UI 3.0.0.
  */
 class NOVTABLE rendering_options : public service_base {
 public:
@@ -200,8 +199,7 @@ private:
 /**
  * Defines a font, as configured in Columns UI Colours and fonts preferences.
  *
- * \note Part of the preliminary DirectWrite-friendly manager_v3 interface.
- *       Subject to change before the final Columns UI 3.0.0 release.
+ * \note Added in Columns UI 3.0.0.
  *
  * The recommended methods to use are create_text_format() and rendering_options().
  * However, access to the underlying data is also provided for less common use cases.
@@ -326,10 +324,9 @@ public:
 };
 
 /**
- * Preliminary DirectWrite-friendly manager_v3 interface.
+ * DirectWrite-friendly manager_v3 interface.
  *
- * \note Part of the preliminary DirectWrite-friendly manager_v3 interface.
- *       Subject to change before the final Columns UI 3.0.0 release.
+ * \note Added in Columns UI 3.0.0.
  */
 class NOVTABLE manager_v3 : public service_base {
 public:

--- a/font_utils.h
+++ b/font_utils.h
@@ -33,7 +33,7 @@ namespace cui::fonts {
 /**
  * Get a font::ptr for a particular font. This is mainly intended for DirectWrite usage.
  *
- * \note Requires Columns UI 3.0.0 alpha 1 or newer. You must check if the returned service pointer
+ * \note Requires Columns UI 3.0.0 or newer. You must check if the returned service pointer
  *       is valid.
  *
  * \param font_id font client or common font GUID

--- a/ui_extension.h
+++ b/ui_extension.h
@@ -1,7 +1,7 @@
 #ifndef _UI_EXTENSION_H_
 #define _UI_EXTENSION_H_
 
-#define UI_EXTENSION_VERSION "8.0.0-rc.1"
+#define UI_EXTENSION_VERSION "8.0.0"
 
 #ifndef CUI_SDK_DWRITE_ENABLED
 #define CUI_SDK_DWRITE_ENABLED __has_include(<dwrite_3.h>)


### PR DESCRIPTION
This removes the notes saying font_manager_v3 and related services are subject to change, updates the docs and bumps the version to 8.0.0,