### PR TITLE
Add splitter_window_v3 for reordering panels

### DIFF
--- a/docs/source/panel/splitter-window.rst
+++ b/docs/source/panel/splitter-window.rst
@@ -10,6 +10,8 @@ Splitter
 
 .. doxygenclass:: uie::splitter_window_v2
 
+.. doxygenclass:: uie::splitter_window_v3
+
 Splitter items
 --------------
 

--- a/splitter.h
+++ b/splitter.h
@@ -468,5 +468,29 @@ public:
 
     FB2K_MAKE_SERVICE_INTERFACE(splitter_window_v2, splitter_window);
 };
+
+/**
+ * \brief Extends uie::splitter_window_v2, adding support for reordering panels.
+ *
+ * \note New in Columns UI 3.1.0.
+ */
+class NOVTABLE splitter_window_v3 : public splitter_window_v2 {
+public:
+    /**
+     * \brief Reorder child panels in this splitter.
+     *
+     * \param  [in]     order            A pointer to an array of new positions for each panel.
+     * \param  [in]     count            The number of elements in the array.
+     *
+     * The `count` argument must be equal to the value returned by `get_panel_count()`.
+     *
+     * \note It’s valid to call this method both before and after the panel window has been
+     * created.
+     */
+    virtual void reorder_panels(const size_t* order, size_t count) = 0;
+
+    FB2K_MAKE_SERVICE_INTERFACE(splitter_window_v3, splitter_window_v2);
+};
+
 } // namespace uie
 #endif //_COLUMNS_API_SPLITTER_H_

--- a/ui_extension.cpp
+++ b/ui_extension.cpp
@@ -95,6 +95,9 @@ const GUID uie::window_host_with_control::class_guid
 
 #endif
 
+const GUID uie::splitter_window_v3::class_guid
+    = {0xbd79d2fe, 0xc21b, 0x4be0, {0x91, 0x7c, 0xf4, 0xce, 0x69, 0xc0, 0x03, 0x11}};
+
 HWND uFindParentPopup(HWND wnd_child)
 {
     HWND wnd_temp = _GetParent(wnd_child);


### PR DESCRIPTION
This adds a `splitter_window_v3` service which extends `splitter_window_v2` with a method for reordering child panels.