### PR TITLE
Add splitter_window_v3 to upgrading docs page

### DIFF
--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -4,6 +4,10 @@ Upgrading the SDK
 Development version
 -------------------
 
+The following service was added:
+
+- :class:`uie::splitter_window_v3`
+
 The following functions were added:
 
 - :func:`uie::utils::remap_category()`


### PR DESCRIPTION
This adds a mention of `uie::splitter_window_v3` in the Upgrading page in the docs.