### PR TITLE
Add section on exception handling to docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -78,6 +78,22 @@ If you wish to provide default bitmaps and additional information for your menu
 items, derive from :class:`uie::menu_button`. If you wish to implement a custom
 button not based upon a menu item, derive from :class:`uie::custom_button`.
 
+Exception handling
+==================
+
+Implementations of virtual functions are not expected to throw C++ exceptions
+unless the documentation for the method mentions that exceptions may be thrown.
+It’s recommended that you declare implementations of virtual functions as
+noexcept_ when exceptions are not expected.
+
+Additionally, callback functions that are passed to the Win32 API, such as
+window procedures, are generally not expected to throw C++ exceptions and hence
+declaring them noexcept_ is recommended.
+
+noexcept_ will cause `std::terminate()`_ to be called if the function does throw
+an exception. This will result in an immediate crash, rather than allowing the
+exception to escape and cause messier crashes or other problems.
+
 Standard windows
 ================
 
@@ -97,3 +113,7 @@ not use them as GUIDs for your own windows.
 .. _foobar2000 sdk: http://www.foobar2000.org/SDK
 
 .. _microsoft visual studio 2022: https://visualstudio.microsoft.com/downloads/
+
+.. _noexcept: https://en.cppreference.com/w/cpp/language/noexcept_spec.html
+
+.. _std::terminate(): https://en.cppreference.com/w/cpp/error/terminate.html

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -2,9 +2,9 @@
  Upgrading the SDK
 ###################
 
-*********************
- Development version
-*********************
+***************
+ Version 8.1.0
+***************
 
 The following service was added:
 

--- a/window.h
+++ b/window.h
@@ -192,7 +192,7 @@ public:
      * \param [in]    p_host            Pointer to the host that creates the extension.
      *                                This parameter may not be NULL.
      * \param [in]    p_position        Initial position of the window
-     * \return                        Window handle of the panel or toolbar window
+     * \return                        Window handle of the panel or toolbar window, or `nullptr` on failure
      */
     virtual HWND create_or_transfer_window(HWND wnd_parent, const window_host_ptr& p_host,
         const ui_helpers::window_position_t& p_position = ui_helpers::window_position_null) = 0;


### PR DESCRIPTION
This adds a small section to the docs about exception handling, to clarify that functions should not throw exceptions unless the documentation indicates that they do.