### PR TITLE
Prepare for 8.1.0 release

### DIFF
--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -16,7 +16,7 @@ The following functions were added:
 - :func:`uie::utils::get_remapped_category()`
 - :func:`cui::config_objects::get_use_smooth_scrolling()`
 
-The following named constants were added:
+The following named constant was added:
 
 - :var:`cui::config_objects::guid_bool_use_smooth_scrolling`
 

--- a/ui_extension.h
+++ b/ui_extension.h
@@ -1,7 +1,7 @@
 #ifndef _UI_EXTENSION_H_
 #define _UI_EXTENSION_H_
 
-#define UI_EXTENSION_VERSION "8.0.0"
+#define UI_EXTENSION_VERSION "8.1.0"
 
 #ifndef CUI_SDK_DWRITE_ENABLED
 #define CUI_SDK_DWRITE_ENABLED __has_include(<dwrite_3.h>)


### PR DESCRIPTION
This updates the SDK version number in the `UI_EXTENSION_VERSION` preprocessor macro and makes a small tweak to the upgrading docs.